### PR TITLE
Add code coverage and badge(s)

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,5 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   matrix:
@@ -17,4 +18,5 @@ script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All Notable changes to `twilio` will be documented in this file
+All notable changes to `twilio` will be documented in this file
 
 ## 1.0.0 - 201X-XX-XX
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://img.shields.io/travis/laravel-notification-channels/twilio/master.svg?style=flat-square)](https://travis-ci.org/laravel-notification-channels/twilio)
 [![StyleCI](https://styleci.io/repos/65543339/shield)](https://styleci.io/repos/65543339)
 [![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/twilio.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/twilio)
+[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/twilio/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/twilio/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/twilio.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/twilio)
 
 This package makes it easy to send [Twilio notifications](https://documentation.twilio.com/docs) with Laravel 5.3.
@@ -127,7 +128,7 @@ public function routeNotificationForTwilio()
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
 ## Testing
-    
+
 ``` bash
 $ composer test
 ```


### PR DESCRIPTION
This PR brings this repository up to date with recent changes in the skeleton. The primary part of this PR is a code coverage set up and badge (https://github.com/laravel-notification-channels/skeleton/pull/6).

Also, if this repository did not have the following already, I have:
- added PHP 7.1 to .travis.yml
- fixed a typo in the changelog
