### PR TITLE
Added alphanumeric sending, and messaging service capabilities, support for Twilio SDK 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "twilio/sdk": "^4.11",
         "illuminate/notifications": "5.1.*|5.2.*|5.3.*",
         "illuminate/support": "5.1.*|5.2.*|5.3.*",
-        "illuminate/events": "5.1.*|5.2.*|5.3.*"
+        "illuminate/events": "5.1.*|5.2.*|5.3.*",
+        "illuminate/queue": "5.1.*|5.2.*|5.3.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "twilio/sdk": "^4.11",
+        "twilio/sdk": "^5.4.1",
         "illuminate/notifications": "5.1.*|5.2.*|5.3.*",
         "illuminate/support": "5.1.*|5.2.*|5.3.*",
         "illuminate/events": "5.1.*|5.2.*|5.3.*",

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -39,4 +39,11 @@ class CouldNotSendNotification extends \Exception
             method or a phone_number attribute to your notifiable.'
         );
     }
+
+    public static function missingAlphaNumericSender()
+    {
+        return new static(
+            'Notification was not sent. Missing `alphanumeric_sender` in config'
+        );
+    }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -16,7 +16,9 @@ class CouldNotSendNotification extends \Exception
     {
         $className = get_class($message) ?: 'Unknown';
 
-        return new static("Notification was not sent. Message object class `{$className}` is invalid. It should be either `".SmsMessage::class.'` or `'.CallMessage::class.'`');
+        return new static(
+            "Notification was not sent. Message object class `{$className}` is invalid. It should
+            be either `".SmsMessage::class.'` or `'.CallMessage::class.'`');
     }
 
     /**
@@ -25,5 +27,16 @@ class CouldNotSendNotification extends \Exception
     public static function missingFrom()
     {
         return new static('Notification was not sent. Missing `from` number.');
+    }
+
+    /**
+     * @return static
+     */
+    public static function invalidReceiver()
+    {
+        return new static(
+            'The notifiable did not have a receiving phone number. Add a routeNotificationForTwilio
+            method or a phone_number attribute to your notifiable.'
+        );
     }
 }

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -26,14 +26,14 @@ class Twilio
     public function __construct(TwilioService $twilioService, TwilioConfig $config)
     {
         $this->twilioService = $twilioService;
-        $this->config = $config;
+        $this->config        = $config;
     }
 
     /**
      * Send a TwilioMessage to the a phone number.
      *
      * @param  TwilioMessage $message
-     * @param                $to
+     * @param  string        $to
      * @param bool           $useAlphanumericSender
      * @return mixed
      * @throws CouldNotSendNotification
@@ -55,7 +55,14 @@ class Twilio
         throw CouldNotSendNotification::invalidMessageObject($message);
     }
 
-    protected function sendSmsMessage($message, $to)
+    /**
+     * Send an sms message using the Twilio Service.
+     *
+     * @param TwilioSmsMessage $message
+     * @param string           $to
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance
+     */
+    protected function sendSmsMessage(TwilioSmsMessage $message, $to)
     {
         $params = [
             'from' => $this->getFrom($message),
@@ -69,7 +76,14 @@ class Twilio
         return $this->twilioService->messages->create($to, $params);
     }
 
-    protected function makeCall($message, $to)
+    /**
+     * Make a call using the Twilio Service.
+     *
+     * @param TwilioCallMessage $message
+     * @param string            $to
+     * @return \Twilio\Rest\Api\V2010\Account\CallInstance
+     */
+    protected function makeCall(TwilioCallMessage $message, $to)
     {
         return $this->twilioService->calls->create(
             $to,
@@ -78,21 +92,31 @@ class Twilio
         );
     }
 
-    protected function getFrom($message)
+    /**
+     * Get the from address from message, or config.
+     *
+     * @param TwilioMessage $message
+     * @return string
+     * @throws CouldNotSendNotification
+     */
+    protected function getFrom(TwilioMessage $message)
     {
-        if (! $from = $message->getFrom() ?: $this->config->getFrom()) {
+        if ( ! $from = $message->getFrom() ?: $this->config->getFrom()) {
             throw CouldNotSendNotification::missingFrom();
         }
 
         return $from;
     }
 
+    /**
+     * Get the alphanumeric sender from config, if one exists.
+     *
+     * @return string|null
+     */
     protected function getAlphanumericSender()
     {
         if ($sender = $this->config->getAlphanumericSender()) {
             return $sender;
         }
-
-        return null;
     }
 }

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace NotificationChannels\Twilio;
+
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
+use Services_Twilio as TwilioService;
+
+class Twilio
+{
+    /**
+     * @var TwilioService
+     */
+    protected $twilioService;
+
+    /**
+     * Default 'from' from config.
+     * @var string
+     */
+    protected $from;
+
+    /**
+     * Twilio constructor.
+     *
+     * @param  TwilioService  $twilioService
+     * @param  string  $from
+     */
+    public function __construct(TwilioService $twilioService, $from)
+    {
+        $this->twilioService = $twilioService;
+        $this->from = $from;
+    }
+
+    /**
+     * Send a TwilioMessage to the a phone number.
+     *
+     * @param  TwilioMessage  $message
+     * @param  $to
+     * @return mixed
+     * @throws CouldNotSendNotification
+     */
+    public function sendMessage(TwilioMessage $message, $to)
+    {
+        if ($message instanceof TwilioSmsMessage) {
+            return $this->sendSmsMessage($message, $to);
+        }
+
+        if ($message instanceof TwilioCallMessage) {
+            return $this->makeCall($message, $to);
+        }
+
+        throw CouldNotSendNotification::invalidMessageObject($message);
+    }
+
+    protected function sendSmsMessage($message, $to)
+    {
+        return $this->twilioService->account->messages->sendMessage(
+            $this->getFrom($message),
+            $to,
+            trim($message->content)
+        );
+    }
+
+    protected function makeCall($message, $to)
+    {
+        return $this->twilioService->account->calls->create(
+            $this->getFrom($message),
+            $to,
+            trim($message->content)
+        );
+    }
+
+    protected function getFrom($message)
+    {
+        if (! $from = $message->from ?: $this->from) {
+            throw CouldNotSendNotification::missingFrom();
+        }
+
+        return $from;
+    }
+}

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -3,7 +3,7 @@
 namespace NotificationChannels\Twilio;
 
 use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
-use Services_Twilio as TwilioService;
+use Twilio\Rest\Client as TwilioService;
 
 class Twilio
 {
@@ -57,21 +57,24 @@ class Twilio
 
     protected function sendSmsMessage($message, $to)
     {
-        return $this->twilioService->account->messages->sendMessage(
-            $this->getFrom($message),
-            $to,
-            trim($message->content),
-            null,
-            $this->config->getSmsParams()
-        );
+        $params = [
+            'from' => $this->getFrom($message),
+            'body' => trim($message->content),
+        ];
+
+        if ($serviceSid = $this->config->getServiceSid()) {
+            $params['messagingServiceSid'] = $serviceSid;
+        }
+
+        $this->twilioService->messages->create($to, $params);
     }
 
     protected function makeCall($message, $to)
     {
-        return $this->twilioService->account->calls->create(
-            $this->getFrom($message),
+        return $this->twilioService->calls->create(
             $to,
-            trim($message->content)
+            $this->getFrom($message),
+            ['url' => trim($message->content)]
         );
     }
 

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -66,7 +66,7 @@ class Twilio
             $params['messagingServiceSid'] = $serviceSid;
         }
 
-        $this->twilioService->messages->create($to, $params);
+        return $this->twilioService->messages->create($to, $params);
     }
 
     protected function makeCall($message, $to)

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -26,7 +26,7 @@ class Twilio
     public function __construct(TwilioService $twilioService, TwilioConfig $config)
     {
         $this->twilioService = $twilioService;
-        $this->config        = $config;
+        $this->config = $config;
     }
 
     /**
@@ -101,7 +101,7 @@ class Twilio
      */
     protected function getFrom(TwilioMessage $message)
     {
-        if ( ! $from = $message->getFrom() ?: $this->config->getFrom()) {
+        if (! $from = $message->getFrom() ?: $this->config->getFrom()) {
             throw CouldNotSendNotification::missingFrom();
         }
 

--- a/src/TwilioCallMessage.php
+++ b/src/TwilioCallMessage.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Twilio;
 
-class TwilioCallMessage extends TwilioAbstractMessage
+class TwilioCallMessage extends TwilioMessage
 {
     /**
      * Set the message url.

--- a/src/TwilioCallMessage.php
+++ b/src/TwilioCallMessage.php
@@ -7,8 +7,7 @@ class TwilioCallMessage extends TwilioMessage
     /**
      * Set the message url.
      *
-     * @param  string  $url
-     *
+     * @param  string $url
      * @return $this
      */
     public function url($url)

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -43,15 +43,15 @@ class TwilioChannel
     public function send($notifiable, Notification $notification)
     {
         try {
-            $to        = $this->getTo($notifiable);
-            $message   = $notification->toTwilio($notifiable);
+            $to = $this->getTo($notifiable);
+            $message = $notification->toTwilio($notifiable);
             $useSender = $this->canReceiveAlphanumericSender($notifiable);
 
             if (is_string($message)) {
                 $message = new TwilioSmsMessage($message);
             }
 
-            if ( ! $message instanceof TwilioMessage) {
+            if (! $message instanceof TwilioMessage) {
                 throw CouldNotSendNotification::invalidMessageObject($message);
             }
 

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -23,8 +23,8 @@ class TwilioChannel
     /**
      * TwilioChannel constructor.
      *
-     * @param Twilio  $twilio
-     * @param Dispatcher  $events
+     * @param Twilio     $twilio
+     * @param Dispatcher $events
      */
     public function __construct(Twilio $twilio, Dispatcher $events)
     {
@@ -35,23 +35,23 @@ class TwilioChannel
     /**
      * Send the given notification.
      *
-     * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  mixed                                  $notifiable
+     * @param  \Illuminate\Notifications\Notification $notification
      * @return mixed
      * @throws CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
     {
         try {
-            $to = $this->getTo($notifiable);
-            $message = $notification->toTwilio($notifiable);
+            $to        = $this->getTo($notifiable);
+            $message   = $notification->toTwilio($notifiable);
             $useSender = $this->canReceiveAlphanumericSender($notifiable);
 
             if (is_string($message)) {
                 $message = new TwilioSmsMessage($message);
             }
 
-            if (! $message instanceof TwilioMessage) {
+            if ( ! $message instanceof TwilioMessage) {
                 throw CouldNotSendNotification::invalidMessageObject($message);
             }
 
@@ -63,6 +63,13 @@ class TwilioChannel
         }
     }
 
+    /**
+     * Get the address to send a notification to.
+     *
+     * @param mixed $notifiable
+     * @return mixed
+     * @throws CouldNotSendNotification
+     */
     protected function getTo($notifiable)
     {
         if ($notifiable->routeNotificationFor('twilio')) {
@@ -76,7 +83,8 @@ class TwilioChannel
     }
 
     /**
-     * Get the alphanumeric sender
+     * Get the alphanumeric sender.
+     *
      * @param $notifiable
      * @return mixed|null
      * @throws CouldNotSendNotification

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -45,6 +45,7 @@ class TwilioChannel
         try {
             $to = $this->getTo($notifiable);
             $message = $notification->toTwilio($notifiable);
+            $useSender = $this->canReceiveAlphanumericSender($notifiable);
 
             if (is_string($message)) {
                 $message = new TwilioSmsMessage($message);
@@ -54,7 +55,7 @@ class TwilioChannel
                 throw CouldNotSendNotification::invalidMessageObject($message);
             }
 
-            return $this->twilio->sendMessage($message, $to);
+            return $this->twilio->sendMessage($message, $to, $useSender);
         } catch (Exception $exception) {
             $this->events->fire(
                 new NotificationFailed($notifiable, $notification, 'twilio', ['message' => $exception->getMessage()])
@@ -72,5 +73,17 @@ class TwilioChannel
         }
 
         throw CouldNotSendNotification::invalidReceiver();
+    }
+
+    /**
+     * Get the alphanumeric sender
+     * @param $notifiable
+     * @return mixed|null
+     * @throws CouldNotSendNotification
+     */
+    protected function canReceiveAlphanumericSender($notifiable)
+    {
+        return (method_exists($notifiable, 'canReceiveAlphanumericSender') &&
+            $notifiable->canReceiveAlphanumericSender());
     }
 }

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -91,7 +91,7 @@ class TwilioChannel
      */
     protected function canReceiveAlphanumericSender($notifiable)
     {
-        return (method_exists($notifiable, 'canReceiveAlphanumericSender') &&
-            $notifiable->canReceiveAlphanumericSender());
+        return method_exists($notifiable, 'canReceiveAlphanumericSender') &&
+        $notifiable->canReceiveAlphanumericSender();
     }
 }

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NotificationChannels\Twilio;
 
 class TwilioConfig

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -18,39 +18,57 @@ class TwilioConfig
         $this->config = $config;
     }
 
+    /**
+     * Get the account sid.
+     *
+     * @return string
+     */
     public function getAccountSid()
     {
         return $this->config['account_sid'];
     }
 
+    /**
+     * Get the auth token.
+     *
+     * @return string
+     */
     public function getAuthToken()
     {
         return $this->config['auth_token'];
     }
 
     /**
-     * Get the from entity from config
+     * Get the default from address.
+     *
+     * @return string
      */
     public function getFrom()
     {
         return $this->config['from'];
     }
 
+    /**
+     * Get the alphanumeric sender.
+     *
+     * @return string
+     */
     public function getAlphanumericSender()
     {
         if (isset($this->config['alphanumeric_sender'])) {
             return $this->config['alphanumeric_sender'];
         }
-
-        return null;
     }
 
+    /**
+     * Get the service sid.
+     *
+     * @return string
+     */
     public function getServiceSid()
     {
         if (isset($this->config['sms_service_sid'])) {
             return $this->config['sms_service_sid'];
         }
-
-        return null;
     }
 }

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -1,0 +1,58 @@
+<?php
+namespace NotificationChannels\Twilio;
+
+class TwilioConfig
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * TwilioConfig constructor.
+     *
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getAccountSid()
+    {
+        return $this->config['account_sid'];
+    }
+
+    public function getAuthToken()
+    {
+        return $this->config['auth_token'];
+    }
+
+    /**
+     * Get the from entity from config
+     */
+    public function getFrom()
+    {
+        return $this->config['from'];
+    }
+
+    public function getAlphanumericSender()
+    {
+        if (isset($this->config['alphanumeric_sender'])) {
+            return $this->config['alphanumeric_sender'];
+        }
+
+        return null;
+    }
+
+    public function getSmsParams()
+    {
+        $params = [];
+
+        if (isset($this->config['sms_service_sid'])) {
+            $params['MessagingServiceSid'] = $this->config['sms_service_sid'];
+        }
+
+        return $params;
+    }
+}

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -45,14 +45,12 @@ class TwilioConfig
         return null;
     }
 
-    public function getSmsParams()
+    public function getServiceSid()
     {
-        $params = [];
-
         if (isset($this->config['sms_service_sid'])) {
-            $params['MessagingServiceSid'] = $this->config['sms_service_sid'];
+            return $this->config['sms_service_sid'];
         }
 
-        return $params;
+        return null;
     }
 }

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Twilio;
 
-abstract class TwilioAbstractMessage
+abstract class TwilioMessage
 {
     /**
      * The message content.

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -65,4 +65,13 @@ abstract class TwilioMessage
 
         return $this;
     }
+
+    /**
+     * Get the from address
+     * @return string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
 }

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -19,8 +19,8 @@ abstract class TwilioMessage
     public $from;
 
     /**
+     * Create a message object.
      * @param string $content
-     *
      * @return static
      */
     public static function create($content = '')
@@ -31,7 +31,7 @@ abstract class TwilioMessage
     /**
      * Create a new message instance.
      *
-     * @param  string  $content
+     * @param  string $content
      */
     public function __construct($content = '')
     {
@@ -41,8 +41,7 @@ abstract class TwilioMessage
     /**
      * Set the message content.
      *
-     * @param  string  $content
-     *
+     * @param  string $content
      * @return $this
      */
     public function content($content)
@@ -55,8 +54,7 @@ abstract class TwilioMessage
     /**
      * Set the phone number the message should be sent from.
      *
-     * @param  string  $from
-     *
+     * @param  string $from
      * @return $this
      */
     public function from($from)
@@ -68,6 +66,7 @@ abstract class TwilioMessage
 
     /**
      * Get the from address
+     *
      * @return string
      */
     public function getFrom()

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -65,7 +65,7 @@ abstract class TwilioMessage
     }
 
     /**
-     * Get the from address
+     * Get the from address.
      *
      * @return string
      */

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -3,7 +3,7 @@
 namespace NotificationChannels\Twilio;
 
 use Illuminate\Support\ServiceProvider;
-use Services_Twilio as TwilioService;
+use Twilio\Rest\Client as TwilioService;
 
 class TwilioProvider extends ServiceProvider
 {

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -23,9 +23,9 @@ class TwilioProvider extends ServiceProvider
             });
     }
     
-    /**		
+    /**
      * Register the application services.		
-     */		
+     */
     public function register()		
     {		
     }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -15,7 +15,7 @@ class TwilioProvider extends ServiceProvider
         $this->app->when(TwilioChannel::class)
             ->needs(Twilio::class)
             ->give(function () {
-                $config = $this->app->make(TwilioConfig::class, $this->app['config']['services.twilio']);
+                $config = $this->app->make(TwilioConfig::class);
                 $twilio = $this->app->make(TwilioService::class, [
                     $config->getAccountSid(),
                     $config->getAuthToken(),
@@ -30,5 +30,8 @@ class TwilioProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->bind(TwilioConfig::class, function () {
+            return new TwilioConfig($this->app['config']['services.twilio']);
+        });
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -22,11 +22,11 @@ class TwilioProvider extends ServiceProvider
                 );
             });
     }
-    
+
     /**
      * Register the application services.		
      */
     public function register()		
-    {		
+    {
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -24,9 +24,9 @@ class TwilioProvider extends ServiceProvider
     }
     
     /**		
-      * Register the application services.		
-      */		
-     public function register()		
+     * Register the application services.		
+     */		
+    public function register()		
     {		
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -12,18 +12,16 @@ class TwilioProvider extends ServiceProvider
      */
     public function boot()
     {
+        $config = $this->app->make(TwilioConfig::class, $this->app['config']['services.twilio']);
+        $twilio = $this->app->make(TwilioService::class, [
+            $config->getAccountSid(),
+            $config->getAuthToken(),
+        ]);
+
         $this->app->when(TwilioChannel::class)
             ->needs(Twilio::class)
-            ->give(function () {
-                $config = $this->app['config']['services.twilio'];
-
-                return new Twilio(
-                    $this->app->make(TwilioService::class, [
-                        $config['account_sid'],
-                        $config['auth_token'],
-                    ]),
-                    $config['from']
-                );
+            ->give(function () use ($twilio, $config) {
+                return new Twilio($twilio, $config);
             });
     }
 

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio;
 
 use Illuminate\Support\ServiceProvider;
+use Services_Twilio as TwilioService;
 
 class TwilioProvider extends ServiceProvider
 {
@@ -12,13 +13,16 @@ class TwilioProvider extends ServiceProvider
     public function boot()
     {
         $this->app->when(TwilioChannel::class)
-            ->needs(\Services_Twilio::class)
+            ->needs(Twilio::class)
             ->give(function () {
-                $config = config('services.twilio');
+                $config = $this->app['config']['services.twilio'];
 
-                return new \Services_Twilio(
-                    $config['account_sid'],
-                    $config['auth_token']
+                return new Twilio(
+                    $this->app->make(TwilioService::class, [
+                        $config['account_sid'],
+                        $config['auth_token'],
+                    ]),
+                    $config['from']
                 );
             });
     }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -22,4 +22,11 @@ class TwilioProvider extends ServiceProvider
                 );
             });
     }
+    
+    /**		
+      * Register the application services.		
+      */		
+     public function register()		
+    {		
+    }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -24,9 +24,9 @@ class TwilioProvider extends ServiceProvider
     }
 
     /**
-     * Register the application services.		
+     * Register the application services.
      */
-    public function register()		
+    public function register()
     {
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -12,15 +12,15 @@ class TwilioProvider extends ServiceProvider
      */
     public function boot()
     {
-        $config = $this->app->make(TwilioConfig::class, $this->app['config']['services.twilio']);
-        $twilio = $this->app->make(TwilioService::class, [
-            $config->getAccountSid(),
-            $config->getAuthToken(),
-        ]);
-
         $this->app->when(TwilioChannel::class)
             ->needs(Twilio::class)
-            ->give(function () use ($twilio, $config) {
+            ->give(function () {
+                $config = $this->app->make(TwilioConfig::class, $this->app['config']['services.twilio']);
+                $twilio = $this->app->make(TwilioService::class, [
+                    $config->getAccountSid(),
+                    $config->getAuthToken(),
+                ]);
+
                 return new Twilio($twilio, $config);
             });
     }

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -2,6 +2,6 @@
 
 namespace NotificationChannels\Twilio;
 
-class TwilioSmsMessage extends TwilioAbstractMessage
+class TwilioSmsMessage extends TwilioMessage
 {
 }

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -4,4 +4,34 @@ namespace NotificationChannels\Twilio;
 
 class TwilioSmsMessage extends TwilioMessage
 {
+    /**
+     * @var null|string
+     */
+    public $alphaNumSender = null;
+
+    /**
+     * Get the from address of this message
+     * @return null|string
+     */
+    public function getFrom()
+    {
+        if ($this->from) {
+            return $this->from;
+        }
+
+        if ($this->alphaNumSender && strlen($this->alphaNumSender) > 0) {
+            return $this->alphaNumSender;
+        }
+
+        return null;
+    }
+
+    /**
+     * Set the alphanumeric sender
+     * @param $sender
+     */
+    public function sender($sender)
+    {
+        $this->alphaNumSender = $sender;
+    }
 }

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -23,8 +23,6 @@ class TwilioSmsMessage extends TwilioMessage
         if ($this->alphaNumSender && strlen($this->alphaNumSender) > 0) {
             return $this->alphaNumSender;
         }
-
-        return null;
     }
 
     /**

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -10,7 +10,8 @@ class TwilioSmsMessage extends TwilioMessage
     public $alphaNumSender = null;
 
     /**
-     * Get the from address of this message
+     * Get the from address of this message.
+     *
      * @return null|string
      */
     public function getFrom()
@@ -27,7 +28,8 @@ class TwilioSmsMessage extends TwilioMessage
     }
 
     /**
-     * Set the alphanumeric sender
+     * Set the alphanumeric sender.
+     *
      * @param $sender
      */
     public function sender($sender)

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Notification;
+use Mockery;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+use Services_Twilio as TwilioService;
+use Services_Twilio_Rest_Calls;
+use Services_Twilio_Rest_Messages;
+
+class IntegrationTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioService */
+    protected $twilioService;
+
+    /** @var Notification */
+    protected $notification;
+
+    /** @var Dispatcher */
+    protected $events;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilioService = Mockery::mock(TwilioService::class);
+        $this->twilioService->account = new \stdClass();
+        $this->twilioService->account->messages = Mockery::mock(Services_Twilio_Rest_Messages::class);
+        $this->twilioService->account->calls = Mockery::mock(Services_Twilio_Rest_Calls::class);
+
+        $this->events = Mockery::mock(Dispatcher::class);
+        $this->notification = Mockery::mock(Notification::class);
+    }
+
+    /** @test */
+    public function it_can_send_a_sms_message()
+    {
+        $message = TwilioSmsMessage::create('Message text');
+        $this->notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $twilio = new Twilio($this->twilioService, '+31612345678');
+
+        $channel = new TwilioChannel($twilio, $this->events);
+
+        $this->smsMessageWillBeSentToTwilioWith('+31612345678', '+22222222222', 'Message text');
+
+        $channel->send(new NotifiableWithAttribute(), $this->notification);
+    }
+
+    /** @test */
+    public function it_can_make_a_call()
+    {
+        $message = TwilioCallMessage::create('http://example.com');
+        $this->notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $twilio = new Twilio($this->twilioService, '+31612345678');
+
+        $channel = new TwilioChannel($twilio, $this->events);
+
+        $this->callWillBeSentToTwilioWith('+31612345678', '+22222222222', 'http://example.com');
+
+        $channel->send(new NotifiableWithAttribute(), $this->notification);
+    }
+
+    protected function smsMessageWillBeSentToTwilioWith($from, $to, $message)
+    {
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($from, $to, $message)
+            ->andReturn(true);
+    }
+
+    protected function callWillBeSentToTwilioWith($from, $to, $url)
+    {
+        $this->twilioService->account->calls->shouldReceive('create')
+            ->atLeast()->once()
+            ->with($from, $to, $url)
+            ->andReturn(true);
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -45,14 +45,14 @@ class IntegrationTest extends MockeryTestCase
         $this->notification->shouldReceive('toTwilio')->andReturn($message);
 
         $config = new TwilioConfig([
-            'from' => '+31612345678'
+            'from' => '+31612345678',
         ]);
         $twilio = new Twilio($this->twilioService, $config);
         $channel = new TwilioChannel($twilio, $this->events);
 
         $this->smsMessageWillBeSentToTwilioWith('+22222222222', [
             'from' => '+31612345678',
-            'body' => 'Message text'
+            'body' => 'Message text',
         ]);
 
         $channel->send(new NotifiableWithAttribute(), $this->notification);
@@ -66,7 +66,7 @@ class IntegrationTest extends MockeryTestCase
 
         $config = new TwilioConfig([
             'from' => '+31612345678',
-            'sms_service_sid' => '0123456789'
+            'sms_service_sid' => '0123456789',
         ]);
         $twilio = new Twilio($this->twilioService, $config);
         $channel = new TwilioChannel($twilio, $this->events);
@@ -74,7 +74,7 @@ class IntegrationTest extends MockeryTestCase
         $this->smsMessageWillBeSentToTwilioWith('+22222222222', [
             'from' => '+31612345678',
             'body' => 'Message text',
-            'messagingServiceSid' => '0123456789'
+            'messagingServiceSid' => '0123456789',
         ]);
 
         $channel->send(new NotifiableWithAttribute(), $this->notification);
@@ -88,14 +88,14 @@ class IntegrationTest extends MockeryTestCase
 
         $config = new TwilioConfig([
             'from' => '+31612345678',
-            'alphanumeric_sender' => 'TwilioTest'
+            'alphanumeric_sender' => 'TwilioTest',
         ]);
         $twilio = new Twilio($this->twilioService, $config);
         $channel = new TwilioChannel($twilio, $this->events);
 
         $this->smsMessageWillBeSentToTwilioWith('+33333333333', [
             'from' => 'TwilioTest',
-            'body' => 'Message text'
+            'body' => 'Message text',
         ]);
 
         $channel->send(new NotifiableWithAlphanumericSender(), $this->notification);
@@ -108,13 +108,13 @@ class IntegrationTest extends MockeryTestCase
         $this->notification->shouldReceive('toTwilio')->andReturn($message);
 
         $config = new TwilioConfig([
-            'from' => '+31612345678'
+            'from' => '+31612345678',
         ]);
         $twilio = new Twilio($this->twilioService, $config);
         $channel = new TwilioChannel($twilio, $this->events);
 
         $this->callWillBeSentToTwilioWith('+22222222222', '+31612345678', [
-            'url' => 'http://example.com'
+            'url' => 'http://example.com',
         ]);
 
         $channel->send(new NotifiableWithAttribute(), $this->notification);

--- a/tests/TwilioCallMessageTest.php
+++ b/tests/TwilioCallMessageTest.php
@@ -3,13 +3,9 @@
 namespace NotificationChannels\Twilio\Test;
 
 use NotificationChannels\Twilio\TwilioCallMessage;
-use PHPUnit_Framework_TestCase;
 
-class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
+class TwilioCallMessageTest extends TwilioMessageTest
 {
-    /** @var \NotificationChannels\Twilio\TwilioCallMessage */
-    protected $message;
-
     public function setUp()
     {
         parent::setUp();
@@ -18,7 +14,7 @@ class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_can_accept_an_url_when_constructing_a_message()
+    public function it_can_accept_a_message_when_constructing_a_message()
     {
         $message = new TwilioCallMessage('http://example.com');
 
@@ -39,13 +35,5 @@ class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
         $this->message->url('http://example.com');
 
         $this->assertEquals('http://example.com', $this->message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_from()
-    {
-        $this->message->from('+1234567890');
-
-        $this->assertEquals('+1234567890', $this->message->from);
     }
 }

--- a/tests/TwilioChannelTest.php
+++ b/tests/TwilioChannelTest.php
@@ -6,13 +6,13 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Mockery;
 use Illuminate\Notifications\Notification;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\Twilio\TwilioCallMessage;
 use NotificationChannels\Twilio\TwilioChannel;
 use NotificationChannels\Twilio\TwilioSmsMessage;
-use PHPUnit_Framework_TestCase;
 use NotificationChannels\Twilio\Twilio;
 
-class TwilioChannelTest extends PHPUnit_Framework_TestCase
+class TwilioChannelTest extends MockeryTestCase
 {
     /** @var TwilioChannel */
     protected $channel;
@@ -59,7 +59,7 @@ class TwilioChannelTest extends PHPUnit_Framework_TestCase
 
         $this->twilio->shouldReceive('sendMessage')
             ->atLeast()->once()
-            ->with($message, '+1111111111');
+            ->with($message, '+1111111111', false);
 
         $this->channel->send($notifiable, $notification);
     }
@@ -75,7 +75,7 @@ class TwilioChannelTest extends PHPUnit_Framework_TestCase
 
         $this->twilio->shouldReceive('sendMessage')
             ->atLeast()->once()
-            ->with($message, '+22222222222');
+            ->with($message, '+22222222222', false);
 
         $this->channel->send($notifiable, $notification);
     }
@@ -90,7 +90,7 @@ class TwilioChannelTest extends PHPUnit_Framework_TestCase
 
         $this->twilio->shouldReceive('sendMessage')
             ->atLeast()->once()
-            ->with(Mockery::type(TwilioSmsMessage::class), Mockery::any());
+            ->with(Mockery::type(TwilioSmsMessage::class), Mockery::any(), false);
 
         $this->channel->send($notifiable, $notification);
     }
@@ -135,5 +135,19 @@ class NotifiableWithAttribute
 
     public function routeNotificationFor()
     {
+    }
+}
+
+class NotifiableWithAlphanumericSender
+{
+    public $phone_number = '+33333333333';
+
+    public function routeNotificationFor()
+    {
+    }
+
+    public function canReceiveAlphanumericSender()
+    {
+        return true;
     }
 }

--- a/tests/TwilioChannelTest.php
+++ b/tests/TwilioChannelTest.php
@@ -110,6 +110,22 @@ class TwilioChannelTest extends MockeryTestCase
 
         $this->channel->send($notifiable, $notification);
     }
+
+    /** @test */
+    public function it_will_send_using_alphanumeric_if_notifiable_can_receive()
+    {
+        $notifiable = new NotifiableWithAlphanumericSender();
+        $notification = Mockery::mock(Notification::class);
+
+        $message = new TwilioSmsMessage('Message text');
+        $notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($message, '+33333333333', true);
+
+        $this->channel->send($notifiable, $notification);
+    }
 }
 
 class Notifiable

--- a/tests/TwilioChannelTest.php
+++ b/tests/TwilioChannelTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use Mockery;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+
+class TwilioChannelTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioChannel */
+    protected $channel;
+
+    /** @var Twilio */
+    protected $twilio;
+
+    /** @var Dispatcher */
+    protected $dispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilio = Mockery::mock(Twilio::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+
+        $this->channel = new TwilioChannel($this->twilio, $this->dispatcher);
+    }
+
+    /** @test */
+    public function it_will_not_send_a_message_without_known_receiver()
+    {
+        $notifiable = new Notifiable();
+        $notification = Mockery::mock(Notification::class);
+
+        $this->dispatcher->shouldReceive('fire')
+            ->atLeast()->once()
+            ->with(Mockery::type(NotificationFailed::class));
+
+        $result = $this->channel->send($notifiable, $notification);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_will_send_a_sms_message_to_the_result_of_the_route_method_of_the_notifiable()
+    {
+        $notifiable = new NotifiableWithMethod();
+        $notification = Mockery::mock(Notification::class);
+
+        $message = new TwilioSmsMessage('Message text');
+        $notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($message, '+1111111111');
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_make_a_call_to_the_phone_number_attribute_of_the_notifiable()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        $message = new TwilioCallMessage('http://example.com');
+        $notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($message, '+22222222222');
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_convert_a_string_to_a_sms_message()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        $notification->shouldReceive('toTwilio')->andReturn('Message text');
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with(Mockery::type(TwilioSmsMessage::class), Mockery::any());
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_fire_an_event_in_case_of_an_invalid_message()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        // Invalid message
+        $notification->shouldReceive('toTwilio')->andReturn(-1);
+
+        $this->dispatcher->shouldReceive('fire')
+            ->atLeast()->once()
+            ->with(Mockery::type(NotificationFailed::class));
+
+        $this->channel->send($notifiable, $notification);
+    }
+}
+
+class Notifiable
+{
+    public $phone_number = null;
+
+    public function routeNotificationFor()
+    {
+    }
+}
+
+class NotifiableWithMethod
+{
+    public function routeNotificationFor()
+    {
+        return '+1111111111';
+    }
+}
+
+class NotifiableWithAttribute
+{
+    public $phone_number = '+22222222222';
+
+    public function routeNotificationFor()
+    {
+    }
+}

--- a/tests/TwilioMessageTest.php
+++ b/tests/TwilioMessageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use NotificationChannels\Twilio\TwilioMessage;
+use PHPUnit_Framework_TestCase;
+
+abstract class TwilioMessageTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioMessage */
+    protected $message;
+
+    /** @test */
+    abstract public function it_can_accept_a_message_when_constructing_a_message();
+
+    /** @test */
+    abstract public function it_provides_a_create_method();
+
+    /** @test */
+    public function it_can_set_the_content()
+    {
+        $this->message->content('myMessage');
+
+        $this->assertEquals('myMessage', $this->message->content);
+    }
+
+    /** @test */
+    public function it_can_set_the_from()
+    {
+        $this->message->from('+1234567890');
+
+        $this->assertEquals('+1234567890', $this->message->from);
+    }
+}

--- a/tests/TwilioMessageTest.php
+++ b/tests/TwilioMessageTest.php
@@ -2,10 +2,10 @@
 
 namespace NotificationChannels\Twilio\Test;
 
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\Twilio\TwilioMessage;
-use PHPUnit_Framework_TestCase;
 
-abstract class TwilioMessageTest extends PHPUnit_Framework_TestCase
+abstract class TwilioMessageTest extends MockeryTestCase
 {
     /** @var TwilioMessage */
     protected $message;

--- a/tests/TwilioMessageTest.php
+++ b/tests/TwilioMessageTest.php
@@ -31,4 +31,12 @@ abstract class TwilioMessageTest extends MockeryTestCase
 
         $this->assertEquals('+1234567890', $this->message->from);
     }
+
+    /** @test */
+    public function it_can_return_the_from_using_getter()
+    {
+        $this->message->from('+1234567890');
+
+        $this->assertEquals('+1234567890', $this->message->getFrom());
+    }
 }

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioProvider;
+use PHPUnit_Framework_TestCase;
+use Services_Twilio as TwilioService;
+use NotificationChannels\Twilio\Twilio;
+use ArrayAccess;
+
+class TwilioProviderTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioProvider */
+    protected $provider;
+
+    /** @var App */
+    protected $app;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->app = Mockery::mock(App::class);
+        $this->provider = new TwilioProvider($this->app);
+
+        $this->app->shouldReceive('make')->andReturn(Mockery::mock(TwilioService::class));
+        $this->app->shouldReceive('flush');
+    }
+
+    /** @test */
+    public function it_gives_an_instantiated_twilio_object_when_the_channel_asks_for_it()
+    {
+        $this->app->shouldReceive('offsetGet')
+            ->with('config')
+            ->andReturn([
+                'services.twilio' => [
+                        'account_sid' => 'sid',
+                        'auth_token' => 'token',
+                        'from' => 'from',
+                    ],
+            ]);
+
+        $this->app->shouldReceive('when')->with(TwilioChannel::class)->once()->andReturn($this->app);
+        $this->app->shouldReceive('needs')->with(Twilio::class)->once()->andReturn($this->app);
+        $this->app->shouldReceive('give')->with(Mockery::on(function ($twilio) {
+            return  $twilio() instanceof Twilio;
+        }))->once();
+
+        $this->provider->boot();
+    }
+}
+
+interface App extends Application, ArrayAccess
+{
+}

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -49,7 +49,7 @@ class TwilioProviderTest extends MockeryTestCase
 
         $this->app->shouldReceive('make')->with(TwilioService::class, [
             $configArray['account_sid'],
-            $configArray['auth_token']
+            $configArray['auth_token'],
         ])->andReturn($twilio);
 
         $this->app->shouldReceive('when')->with(TwilioChannel::class)->once()->andReturn($this->app);

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -4,14 +4,15 @@ namespace NotificationChannels\Twilio\Test;
 
 use Illuminate\Contracts\Foundation\Application;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioProvider;
-use PHPUnit_Framework_TestCase;
 use Services_Twilio as TwilioService;
 use NotificationChannels\Twilio\Twilio;
 use ArrayAccess;
 
-class TwilioProviderTest extends PHPUnit_Framework_TestCase
+class TwilioProviderTest extends MockeryTestCase
 {
     /** @var TwilioProvider */
     protected $provider;
@@ -26,27 +27,42 @@ class TwilioProviderTest extends PHPUnit_Framework_TestCase
         $this->app = Mockery::mock(App::class);
         $this->provider = new TwilioProvider($this->app);
 
-        $this->app->shouldReceive('make')->andReturn(Mockery::mock(TwilioService::class));
-        $this->app->shouldReceive('flush');
+        //$this->app->shouldReceive('make')->once()->andReturn(Mockery::mock(TwilioService::class));
+        //$this->app->shouldReceive('flush');
     }
 
     /** @test */
     public function it_gives_an_instantiated_twilio_object_when_the_channel_asks_for_it()
     {
+        $configArray = [
+            'account_sid' => 'sid',
+            'auth_token' => 'token',
+            'from' => 'from',
+        ];
+        $twilio = Mockery::mock(TwilioService::class);
+        $config = Mockery::mock(TwilioConfig::class, $configArray);
+
         $this->app->shouldReceive('offsetGet')
+            ->once()
             ->with('config')
             ->andReturn([
-                'services.twilio' => [
-                        'account_sid' => 'sid',
-                        'auth_token' => 'token',
-                        'from' => 'from',
-                    ],
+                'services.twilio' => $configArray
             ]);
+
+        $this->app->shouldReceive('make')->with(TwilioConfig::class, $configArray)->andReturn($config);
+
+        $config->shouldReceive('getAccountSid')->once()->andReturn($configArray['account_sid']);
+        $config->shouldReceive('getAuthToken')->once()->andReturn($configArray['auth_token']);
+
+        $this->app->shouldReceive('make')->with(TwilioService::class, [
+            $configArray['account_sid'],
+            $configArray['auth_token']
+        ])->andReturn($twilio);
 
         $this->app->shouldReceive('when')->with(TwilioChannel::class)->once()->andReturn($this->app);
         $this->app->shouldReceive('needs')->with(Twilio::class)->once()->andReturn($this->app);
         $this->app->shouldReceive('give')->with(Mockery::on(function ($twilio) {
-            return  $twilio() instanceof Twilio;
+            return $twilio() instanceof Twilio;
         }))->once();
 
         $this->provider->boot();

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -8,7 +8,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\Twilio\TwilioChannel;
 use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioProvider;
-use Services_Twilio as TwilioService;
+use Twilio\Rest\Client as TwilioService;
 use NotificationChannels\Twilio\Twilio;
 use ArrayAccess;
 

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -42,14 +42,7 @@ class TwilioProviderTest extends MockeryTestCase
         $twilio = Mockery::mock(TwilioService::class);
         $config = Mockery::mock(TwilioConfig::class, $configArray);
 
-        $this->app->shouldReceive('offsetGet')
-            ->once()
-            ->with('config')
-            ->andReturn([
-                'services.twilio' => $configArray
-            ]);
-
-        $this->app->shouldReceive('make')->with(TwilioConfig::class, $configArray)->andReturn($config);
+        $this->app->shouldReceive('make')->with(TwilioConfig::class)->andReturn($config);
 
         $config->shouldReceive('getAccountSid')->once()->andReturn($configArray['account_sid']);
         $config->shouldReceive('getAuthToken')->once()->andReturn($configArray['auth_token']);

--- a/tests/TwilioSmsMessageTest.php
+++ b/tests/TwilioSmsMessageTest.php
@@ -3,13 +3,9 @@
 namespace NotificationChannels\Twilio\Test;
 
 use NotificationChannels\Twilio\TwilioSmsMessage;
-use PHPUnit_Framework_TestCase;
 
-class TwilioSmsMessageTest extends PHPUnit_Framework_TestCase
+class TwilioSmsMessageTest extends TwilioMessageTest
 {
-    /** @var \NotificationChannels\Twilio\TwilioSmsMessage */
-    protected $message;
-
     public function setUp()
     {
         parent::setUp();
@@ -31,21 +27,5 @@ class TwilioSmsMessageTest extends PHPUnit_Framework_TestCase
         $message = TwilioSmsMessage::create('myMessage');
 
         $this->assertEquals('myMessage', $message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_content()
-    {
-        $this->message->content('myMessage');
-
-        $this->assertEquals('myMessage', $this->message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_from()
-    {
-        $this->message->from('+1234567890');
-
-        $this->assertEquals('+1234567890', $this->message->from);
     }
 }

--- a/tests/TwilioSmsMessageTest.php
+++ b/tests/TwilioSmsMessageTest.php
@@ -28,4 +28,22 @@ class TwilioSmsMessageTest extends TwilioMessageTest
 
         $this->assertEquals('myMessage', $message->content);
     }
+
+    /** @test */
+    public function it_sets_alphanumeric_sender()
+    {
+        $message = TwilioSmsMessage::create('myMessage');
+        $message->sender('TestSender');
+
+        $this->assertEquals('TestSender', $message->alphaNumSender);
+    }
+
+    /** @test */
+    public function it_can_return_the_alphanumeric_sender_if_set()
+    {
+        $message = TwilioSmsMessage::create('myMessage');
+        $message->sender('TestSender');
+
+        $this->assertEquals('TestSender', $message->getFrom());
+    }
 }

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery;
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
+use NotificationChannels\Twilio\TwilioMessage;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+use Services_Twilio_Rest_Calls;
+use Services_Twilio_Rest_Messages;
+use Services_Twilio as TwilioService;
+
+class TwilioTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Twilio */
+    protected $twilio;
+
+    /** @var TwilioService */
+    protected $twilioService;
+
+    /** @var Dispatcher */
+    protected $dispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilioService = Mockery::mock(TwilioService::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+
+        $this->twilioService->account = new \stdClass();
+        $this->twilioService->account->messages = Mockery::mock(Services_Twilio_Rest_Messages::class);
+        $this->twilioService->account->calls = Mockery::mock(Services_Twilio_Rest_Calls::class);
+
+        $this->twilio = new Twilio($this->twilioService, '+1234567890');
+    }
+
+    /** @test */
+    public function it_can_send_a_sms_message_to_twilio()
+    {
+        $message = new TwilioSmsMessage('Message text');
+
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with('+1234567890', '+1111111111', 'Message text')
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111');
+    }
+
+    /** @test */
+    public function it_can_send_a_call_to_twilio()
+    {
+        $message = new TwilioCallMessage('http://example.com');
+        $message->from = '+2222222222';
+
+        $this->twilioService->account->calls->shouldReceive('create')
+            ->atLeast()->once()
+            ->with('+2222222222', '+1111111111', 'http://example.com')
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111');
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_in_case_of_a_missing_from_number()
+    {
+        $this->setExpectedException(
+            CouldNotSendNotification::class,
+            'Notification was not sent. Missing `from` number.'
+        );
+
+        $smsMessage = new TwilioSmsMessage('Message text');
+        $twilio = new Twilio($this->twilioService, null);
+
+        $twilio->sendMessage($smsMessage, null);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_in_case_of_an_unrecognized_message_object()
+    {
+        $this->setExpectedException(
+            CouldNotSendNotification::class,
+            'Notification was not sent. Message object class'
+        );
+
+        $this->twilio->sendMessage(new InvalidMessage(), null);
+    }
+}
+
+class InvalidMessage extends TwilioMessage
+{
+}

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -68,6 +68,54 @@ class TwilioTest extends MockeryTestCase
     }
 
     /** @test */
+    public function it_can_send_a_sms_message_to_twilio_with_alphanumeric_sender()
+    {
+        $message = new TwilioSmsMessage('Message text');
+
+        $this->config->shouldReceive('getAlphanumericSender')
+            ->once()
+            ->andReturn('TwilioTest');
+
+        $this->config->shouldNotReceive('getFrom');
+
+        $this->config->shouldReceive('getSmsParams')
+            ->once()
+            ->andReturn([]);
+
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with('TwilioTest', '+1111111111', 'Message text', null, [])
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111', true);
+    }
+
+    /** @test */
+    public function it_can_send_a_sms_message_to_twilio_with_messaging_service()
+    {
+        $message = new TwilioSmsMessage('Message text');
+
+        $this->config->shouldReceive('getFrom')
+            ->once()
+            ->andReturn('+1234567890');
+
+        $this->config->shouldReceive('getSmsParams')
+            ->once()
+            ->andReturn([
+                'MessagingServiceSid' => 'service_sid'
+            ]);
+
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with('+1234567890', '+1111111111', 'Message text', null, [
+                'MessagingServiceSid' => 'service_sid'
+            ])
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111');
+    }
+
+    /** @test */
     public function it_can_send_a_call_to_twilio()
     {
         $message = new TwilioCallMessage('http://example.com');

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -88,7 +88,7 @@ class TwilioTest extends MockeryTestCase
             ->atLeast()->once()
             ->with('+1111111111', [
                 'from' => 'TwilioTest',
-                'body' => 'Message text'
+                'body' => 'Message text',
             ])
             ->andReturn(true);
 
@@ -113,7 +113,7 @@ class TwilioTest extends MockeryTestCase
             ->with('+1111111111', [
                 'from' => '+1234567890',
                 'body' => 'Message text',
-                'messagingServiceSid' => 'service_sid'
+                'messagingServiceSid' => 'service_sid',
             ])
             ->andReturn(true);
 
@@ -129,7 +129,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilioService->calls->shouldReceive('create')
             ->atLeast()->once()
             ->with('+1111111111', '+2222222222', [
-                'url' => 'http://example.com'
+                'url' => 'http://example.com',
             ])
             ->andReturn(true);
 


### PR DESCRIPTION
I have added 2 new features:
### Messaging Service

The ability to use a Twilio Messaging Service. Just add `sms_service_sid` to your Twilio services config, like so:

```
'twilio' => [
    'account_sid'     => env('TWILIO_SID'),
    'auth_token'      => env('TWILIO_TOKEN'),
    'from'            => env('TWILIO_NUMBER'),
    'sms_service_sid' => env('TWILIO_SERVICE_SID'),
]
```
### Alphanumeric Senders

To implement alphanumeric senders, add your sender name to your Twilio services config, like so:

```
'twilio' => [
    'account_sid'     => env('TWILIO_SID'),
    'auth_token'      => env('TWILIO_TOKEN'),
    'from'            => env('TWILIO_NUMBER'),
    'sms_service_sid' => env('TWILIO_SERVICE_SID'),
    'alphanumeric_sender' => 'Sender Name'
]
```

Alphanumeric senders are available on a county-by-country basis (https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID), so you need to implement the following method on your `$notifiable` class:

```
public function canReceiveAlphanumericSender()
{
    return true;
}
```

Use this method to determine whether the Model can receive Alphanumeric senders or not
#### Footnote

I noticed @casperboone's pull request, which looks great, and once pulled in, I'd be happy to contribute these changes to the new format.
