### PR TITLE
Implement register method to satisfy ServiceProvider abstract method

### DIFF
--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -23,9 +23,9 @@ class TwilioProvider extends ServiceProvider
             });
     }
     
-    /**		
+    /**
      * Register the application services.		
-     */		
+     */
     public function register()		
     {		
     }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -22,11 +22,11 @@ class TwilioProvider extends ServiceProvider
                 );
             });
     }
-    
+
     /**
      * Register the application services.		
      */
     public function register()		
-    {		
+    {
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -24,9 +24,9 @@ class TwilioProvider extends ServiceProvider
     }
     
     /**		
-      * Register the application services.		
-      */		
-     public function register()		
+     * Register the application services.		
+     */		
+    public function register()		
     {		
     }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -22,4 +22,11 @@ class TwilioProvider extends ServiceProvider
                 );
             });
     }
+    
+    /**		
+      * Register the application services.		
+      */		
+     public function register()		
+    {		
+    }
 }

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -24,9 +24,9 @@ class TwilioProvider extends ServiceProvider
     }
 
     /**
-     * Register the application services.		
+     * Register the application services.
      */
-    public function register()		
+    public function register()
     {
     }
 }


### PR DESCRIPTION
The `register` method on the ServiceProvider class is marked as **abstract** ([right here](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/ServiceProvider.php#L54)) on Laravel/Lumen 5.2 (and probably earlier).

I am getting the following in Lumen 5.2:

```
FatalErrorException in TwilioProvider.php line 0:

Class NotificationChannels\Twilio\TwilioProvider contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Support\ServiceProvider::register)
```

This commit fixes the issue without changing any functionality.
