### PR TITLE
Add/improve tests, improve testability and refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "twilio/sdk": "^4.11",
         "illuminate/notifications": "5.1.*|5.2.*|5.3.*",
         "illuminate/support": "5.1.*|5.2.*|5.3.*",
-        "illuminate/events": "5.1.*|5.2.*|5.3.*"
+        "illuminate/events": "5.1.*|5.2.*|5.3.*",
+        "illuminate/queue": "5.1.*|5.2.*|5.3.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -16,7 +16,9 @@ class CouldNotSendNotification extends \Exception
     {
         $className = get_class($message) ?: 'Unknown';
 
-        return new static("Notification was not sent. Message object class `{$className}` is invalid. It should be either `".SmsMessage::class.'` or `'.CallMessage::class.'`');
+        return new static(
+            "Notification was not sent. Message object class `{$className}` is invalid. It should
+            be either `".SmsMessage::class.'` or `'.CallMessage::class.'`');
     }
 
     /**
@@ -25,5 +27,16 @@ class CouldNotSendNotification extends \Exception
     public static function missingFrom()
     {
         return new static('Notification was not sent. Missing `from` number.');
+    }
+
+    /**
+     * @return static
+     */
+    public static function invalidReceiver()
+    {
+        return new static(
+            'The notifiable did not have a receiving phone number. Add a routeNotificationForTwilio
+            method or a phone_number attribute to your notifiable.'
+        );
     }
 }

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace NotificationChannels\Twilio;
+
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
+use Services_Twilio as TwilioService;
+
+class Twilio
+{
+    /**
+     * @var TwilioService
+     */
+    protected $twilioService;
+
+    /**
+     * Default 'from' from config.
+     * @var string
+     */
+    protected $from;
+
+    /**
+     * Twilio constructor.
+     *
+     * @param  TwilioService  $twilioService
+     * @param  string  $from
+     */
+    public function __construct(TwilioService $twilioService, $from)
+    {
+        $this->twilioService = $twilioService;
+        $this->from = $from;
+    }
+
+    /**
+     * Send a TwilioMessage to the a phone number.
+     *
+     * @param  TwilioMessage  $message
+     * @param  $to
+     * @return mixed
+     * @throws CouldNotSendNotification
+     */
+    public function sendMessage(TwilioMessage $message, $to)
+    {
+        if ($message instanceof TwilioSmsMessage) {
+            return $this->sendSmsMessage($message, $to);
+        }
+
+        if ($message instanceof TwilioCallMessage) {
+            return $this->makeCall($message, $to);
+        }
+
+        throw CouldNotSendNotification::invalidMessageObject($message);
+    }
+
+    protected function sendSmsMessage($message, $to)
+    {
+        return $this->twilioService->account->messages->sendMessage(
+            $this->getFrom($message),
+            $to,
+            trim($message->content)
+        );
+    }
+
+    protected function makeCall($message, $to)
+    {
+        return $this->twilioService->account->calls->create(
+            $this->getFrom($message),
+            $to,
+            trim($message->content)
+        );
+    }
+
+    protected function getFrom($message)
+    {
+        if (! $from = $message->from ?: $this->from) {
+            throw CouldNotSendNotification::missingFrom();
+        }
+
+        return $from;
+    }
+}

--- a/src/TwilioCallMessage.php
+++ b/src/TwilioCallMessage.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Twilio;
 
-class TwilioCallMessage extends TwilioAbstractMessage
+class TwilioCallMessage extends TwilioMessage
 {
     /**
      * Set the message url.

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\Twilio;
 
-abstract class TwilioAbstractMessage
+abstract class TwilioMessage
 {
     /**
      * The message content.

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio;
 
 use Illuminate\Support\ServiceProvider;
+use Services_Twilio as TwilioService;
 
 class TwilioProvider extends ServiceProvider
 {
@@ -12,13 +13,16 @@ class TwilioProvider extends ServiceProvider
     public function boot()
     {
         $this->app->when(TwilioChannel::class)
-            ->needs(\Services_Twilio::class)
+            ->needs(Twilio::class)
             ->give(function () {
-                $config = config('services.twilio');
+                $config = $this->app['config']['services.twilio'];
 
-                return new \Services_Twilio(
-                    $config['account_sid'],
-                    $config['auth_token']
+                return new Twilio(
+                    $this->app->make(TwilioService::class, [
+                        $config['account_sid'],
+                        $config['auth_token'],
+                    ]),
+                    $config['from']
                 );
             });
     }

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -2,6 +2,6 @@
 
 namespace NotificationChannels\Twilio;
 
-class TwilioSmsMessage extends TwilioAbstractMessage
+class TwilioSmsMessage extends TwilioMessage
 {
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Notification;
+use Mockery;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+use Services_Twilio as TwilioService;
+use Services_Twilio_Rest_Calls;
+use Services_Twilio_Rest_Messages;
+
+class IntegrationTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioService */
+    protected $twilioService;
+
+    /** @var Notification */
+    protected $notification;
+
+    /** @var Dispatcher */
+    protected $events;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilioService = Mockery::mock(TwilioService::class);
+        $this->twilioService->account = new \stdClass();
+        $this->twilioService->account->messages = Mockery::mock(Services_Twilio_Rest_Messages::class);
+        $this->twilioService->account->calls = Mockery::mock(Services_Twilio_Rest_Calls::class);
+
+        $this->events = Mockery::mock(Dispatcher::class);
+        $this->notification = Mockery::mock(Notification::class);
+    }
+
+    /** @test */
+    public function it_can_send_a_sms_message()
+    {
+        $message = TwilioSmsMessage::create('Message text');
+        $this->notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $twilio = new Twilio($this->twilioService, '+31612345678');
+
+        $channel = new TwilioChannel($twilio, $this->events);
+
+        $this->smsMessageWillBeSentToTwilioWith('+31612345678', '+22222222222', 'Message text');
+
+        $channel->send(new NotifiableWithAttribute(), $this->notification);
+    }
+
+    /** @test */
+    public function it_can_make_a_call()
+    {
+        $message = TwilioCallMessage::create('http://example.com');
+        $this->notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $twilio = new Twilio($this->twilioService, '+31612345678');
+
+        $channel = new TwilioChannel($twilio, $this->events);
+
+        $this->callWillBeSentToTwilioWith('+31612345678', '+22222222222', 'http://example.com');
+
+        $channel->send(new NotifiableWithAttribute(), $this->notification);
+    }
+
+    protected function smsMessageWillBeSentToTwilioWith($from, $to, $message)
+    {
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($from, $to, $message)
+            ->andReturn(true);
+    }
+
+    protected function callWillBeSentToTwilioWith($from, $to, $url)
+    {
+        $this->twilioService->account->calls->shouldReceive('create')
+            ->atLeast()->once()
+            ->with($from, $to, $url)
+            ->andReturn(true);
+    }
+}

--- a/tests/TwilioCallMessageTest.php
+++ b/tests/TwilioCallMessageTest.php
@@ -3,13 +3,9 @@
 namespace NotificationChannels\Twilio\Test;
 
 use NotificationChannels\Twilio\TwilioCallMessage;
-use PHPUnit_Framework_TestCase;
 
-class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
+class TwilioCallMessageTest extends TwilioMessageTest
 {
-    /** @var \NotificationChannels\Twilio\TwilioCallMessage */
-    protected $message;
-
     public function setUp()
     {
         parent::setUp();
@@ -18,7 +14,7 @@ class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_can_accept_an_url_when_constructing_a_message()
+    public function it_can_accept_a_message_when_constructing_a_message()
     {
         $message = new TwilioCallMessage('http://example.com');
 
@@ -39,13 +35,5 @@ class TwilioCallMessageTest extends PHPUnit_Framework_TestCase
         $this->message->url('http://example.com');
 
         $this->assertEquals('http://example.com', $this->message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_from()
-    {
-        $this->message->from('+1234567890');
-
-        $this->assertEquals('+1234567890', $this->message->from);
     }
 }

--- a/tests/TwilioChannelTest.php
+++ b/tests/TwilioChannelTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
+use Mockery;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+
+class TwilioChannelTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioChannel */
+    protected $channel;
+
+    /** @var Twilio */
+    protected $twilio;
+
+    /** @var Dispatcher */
+    protected $dispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilio = Mockery::mock(Twilio::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+
+        $this->channel = new TwilioChannel($this->twilio, $this->dispatcher);
+    }
+
+    /** @test */
+    public function it_will_not_send_a_message_without_known_receiver()
+    {
+        $notifiable = new Notifiable();
+        $notification = Mockery::mock(Notification::class);
+
+        $this->dispatcher->shouldReceive('fire')
+            ->atLeast()->once()
+            ->with(Mockery::type(NotificationFailed::class));
+
+        $result = $this->channel->send($notifiable, $notification);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function it_will_send_a_sms_message_to_the_result_of_the_route_method_of_the_notifiable()
+    {
+        $notifiable = new NotifiableWithMethod();
+        $notification = Mockery::mock(Notification::class);
+
+        $message = new TwilioSmsMessage('Message text');
+        $notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($message, '+1111111111');
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_make_a_call_to_the_phone_number_attribute_of_the_notifiable()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        $message = new TwilioCallMessage('http://example.com');
+        $notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with($message, '+22222222222');
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_convert_a_string_to_a_sms_message()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        $notification->shouldReceive('toTwilio')->andReturn('Message text');
+
+        $this->twilio->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with(Mockery::type(TwilioSmsMessage::class), Mockery::any());
+
+        $this->channel->send($notifiable, $notification);
+    }
+
+    /** @test */
+    public function it_will_fire_an_event_in_case_of_an_invalid_message()
+    {
+        $notifiable = new NotifiableWithAttribute();
+        $notification = Mockery::mock(Notification::class);
+
+        // Invalid message
+        $notification->shouldReceive('toTwilio')->andReturn(-1);
+
+        $this->dispatcher->shouldReceive('fire')
+            ->atLeast()->once()
+            ->with(Mockery::type(NotificationFailed::class));
+
+        $this->channel->send($notifiable, $notification);
+    }
+}
+
+class Notifiable
+{
+    public $phone_number = null;
+
+    public function routeNotificationFor()
+    {
+    }
+}
+
+class NotifiableWithMethod
+{
+    public function routeNotificationFor()
+    {
+        return '+1111111111';
+    }
+}
+
+class NotifiableWithAttribute
+{
+    public $phone_number = '+22222222222';
+
+    public function routeNotificationFor()
+    {
+    }
+}

--- a/tests/TwilioMessageTest.php
+++ b/tests/TwilioMessageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use NotificationChannels\Twilio\TwilioMessage;
+use PHPUnit_Framework_TestCase;
+
+abstract class TwilioMessageTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioMessage */
+    protected $message;
+
+    /** @test */
+    abstract public function it_can_accept_a_message_when_constructing_a_message();
+
+    /** @test */
+    abstract public function it_provides_a_create_method();
+
+    /** @test */
+    public function it_can_set_the_content()
+    {
+        $this->message->content('myMessage');
+
+        $this->assertEquals('myMessage', $this->message->content);
+    }
+
+    /** @test */
+    public function it_can_set_the_from()
+    {
+        $this->message->from('+1234567890');
+
+        $this->assertEquals('+1234567890', $this->message->from);
+    }
+}

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioProvider;
+use PHPUnit_Framework_TestCase;
+use Services_Twilio as TwilioService;
+use NotificationChannels\Twilio\Twilio;
+use ArrayAccess;
+
+class TwilioProviderTest extends PHPUnit_Framework_TestCase
+{
+    /** @var TwilioProvider */
+    protected $provider;
+
+    /** @var App */
+    protected $app;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->app = Mockery::mock(App::class);
+        $this->provider = new TwilioProvider($this->app);
+
+        $this->app->shouldReceive('make')->andReturn(Mockery::mock(TwilioService::class));
+        $this->app->shouldReceive('flush');
+    }
+
+    /** @test */
+    public function it_gives_an_instantiated_twilio_object_when_the_channel_asks_for_it()
+    {
+        $this->app->shouldReceive('offsetGet')
+            ->with('config')
+            ->andReturn([
+                'services.twilio' => [
+                        'account_sid' => 'sid',
+                        'auth_token' => 'token',
+                        'from' => 'from',
+                    ],
+            ]);
+
+        $this->app->shouldReceive('when')->with(TwilioChannel::class)->once()->andReturn($this->app);
+        $this->app->shouldReceive('needs')->with(Twilio::class)->once()->andReturn($this->app);
+        $this->app->shouldReceive('give')->with(Mockery::on(function ($twilio) {
+            return  $twilio() instanceof Twilio;
+        }))->once();
+
+        $this->provider->boot();
+    }
+}
+
+interface App extends Application, ArrayAccess
+{
+}

--- a/tests/TwilioSmsMessageTest.php
+++ b/tests/TwilioSmsMessageTest.php
@@ -3,13 +3,9 @@
 namespace NotificationChannels\Twilio\Test;
 
 use NotificationChannels\Twilio\TwilioSmsMessage;
-use PHPUnit_Framework_TestCase;
 
-class TwilioSmsMessageTest extends PHPUnit_Framework_TestCase
+class TwilioSmsMessageTest extends TwilioMessageTest
 {
-    /** @var \NotificationChannels\Twilio\TwilioSmsMessage */
-    protected $message;
-
     public function setUp()
     {
         parent::setUp();
@@ -31,21 +27,5 @@ class TwilioSmsMessageTest extends PHPUnit_Framework_TestCase
         $message = TwilioSmsMessage::create('myMessage');
 
         $this->assertEquals('myMessage', $message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_content()
-    {
-        $this->message->content('myMessage');
-
-        $this->assertEquals('myMessage', $this->message->content);
-    }
-
-    /** @test */
-    public function it_can_set_the_from()
-    {
-        $this->message->from('+1234567890');
-
-        $this->assertEquals('+1234567890', $this->message->from);
     }
 }

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace NotificationChannels\Twilio\Test;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery;
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
+use NotificationChannels\Twilio\TwilioMessage;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit_Framework_TestCase;
+use NotificationChannels\Twilio\Twilio;
+use Services_Twilio_Rest_Calls;
+use Services_Twilio_Rest_Messages;
+use Services_Twilio as TwilioService;
+
+class TwilioTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Twilio */
+    protected $twilio;
+
+    /** @var TwilioService */
+    protected $twilioService;
+
+    /** @var Dispatcher */
+    protected $dispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->twilioService = Mockery::mock(TwilioService::class);
+        $this->dispatcher = Mockery::mock(Dispatcher::class);
+
+        $this->twilioService->account = new \stdClass();
+        $this->twilioService->account->messages = Mockery::mock(Services_Twilio_Rest_Messages::class);
+        $this->twilioService->account->calls = Mockery::mock(Services_Twilio_Rest_Calls::class);
+
+        $this->twilio = new Twilio($this->twilioService, '+1234567890');
+    }
+
+    /** @test */
+    public function it_can_send_a_sms_message_to_twilio()
+    {
+        $message = new TwilioSmsMessage('Message text');
+
+        $this->twilioService->account->messages->shouldReceive('sendMessage')
+            ->atLeast()->once()
+            ->with('+1234567890', '+1111111111', 'Message text')
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111');
+    }
+
+    /** @test */
+    public function it_can_send_a_call_to_twilio()
+    {
+        $message = new TwilioCallMessage('http://example.com');
+        $message->from = '+2222222222';
+
+        $this->twilioService->account->calls->shouldReceive('create')
+            ->atLeast()->once()
+            ->with('+2222222222', '+1111111111', 'http://example.com')
+            ->andReturn(true);
+
+        $this->twilio->sendMessage($message, '+1111111111');
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_in_case_of_a_missing_from_number()
+    {
+        $this->setExpectedException(
+            CouldNotSendNotification::class,
+            'Notification was not sent. Missing `from` number.'
+        );
+
+        $smsMessage = new TwilioSmsMessage('Message text');
+        $twilio = new Twilio($this->twilioService, null);
+
+        $twilio->sendMessage($smsMessage, null);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_in_case_of_an_unrecognized_message_object()
+    {
+        $this->setExpectedException(
+            CouldNotSendNotification::class,
+            'Notification was not sent. Message object class'
+        );
+
+        $this->twilio->sendMessage(new InvalidMessage(), null);
+    }
+}
+
+class InvalidMessage extends TwilioMessage
+{
+}


### PR DESCRIPTION
As this is currently the most downloaded package, I thought the tests needed some attention to prove the working to its users.

**Note:** This PR proposes something a little different than #14. Pick what you like most ;).

I have done the following:
- Used a parallel test hierarchy for the message tests.
- Created tests for the channel
- Created tests for the provider
- Changed the config helper method in the provider to $this->app['config']
- Changed `TwilioAbstractMessage` to `TwilioMessage`
- Created integration tests
- Refactored a lot from `TwilioChannel` to `Twilio`. This made the tests, but also the code in general a lot cleaner and more readable.
- Created tests for `Twilio`
