### PR TITLE
Instantiate Twilio Service through new class instead of container resolving.

### DIFF
--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -18,10 +18,7 @@ class TwilioProvider extends ServiceProvider
                 $config = $this->app['config']['services.twilio'];
 
                 return new Twilio(
-                    $this->app->make(TwilioService::class, [
-                        $config['account_sid'],
-                        $config['auth_token'],
-                    ]),
+                    new TwilioService($config['account_sid'], $config['auth_token']),
                     $config['from']
                 );
             });

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Twilio;
 
-use Illuminate\Support\ServiceProvider;
 use Services_Twilio as TwilioService;
+use Illuminate\Support\ServiceProvider;
 
 class TwilioProvider extends ServiceProvider
 {


### PR DESCRIPTION
Change needed because of API change in Laravel 5.4 $app->make() no longer accepts a second parameter.