### PR TITLE
Fixed the dependency resolution in Laravel 5.4

### DIFF
--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Twilio;
 
-use Illuminate\Support\ServiceProvider;
 use Services_Twilio as TwilioService;
+use Illuminate\Support\ServiceProvider;
 
 class TwilioProvider extends ServiceProvider
 {
@@ -18,13 +18,16 @@ class TwilioProvider extends ServiceProvider
                 $config = $this->app['config']['services.twilio'];
 
                 return new Twilio(
-                    $this->app->make(TwilioService::class, [
-                        $config['account_sid'],
-                        $config['auth_token'],
-                    ]),
+                    $this->app->make(TwilioService::class),
                     $config['from']
                 );
             });
+
+        $this->app->bind(TwilioService::class, function () {
+            $config = $this->app['config']['services.twilio'];
+
+            return new TwilioService($config['account_sid'], $config['auth_token']);
+        });
     }
 
     /**

--- a/tests/TwilioProviderTest.php
+++ b/tests/TwilioProviderTest.php
@@ -2,14 +2,14 @@
 
 namespace NotificationChannels\Twilio\Test;
 
-use Illuminate\Contracts\Foundation\Application;
 use Mockery;
-use NotificationChannels\Twilio\TwilioChannel;
-use NotificationChannels\Twilio\TwilioProvider;
+use ArrayAccess;
 use PHPUnit_Framework_TestCase;
 use Services_Twilio as TwilioService;
 use NotificationChannels\Twilio\Twilio;
-use ArrayAccess;
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioProvider;
+use Illuminate\Contracts\Foundation\Application;
 
 class TwilioProviderTest extends PHPUnit_Framework_TestCase
 {
@@ -48,6 +48,10 @@ class TwilioProviderTest extends PHPUnit_Framework_TestCase
         $this->app->shouldReceive('give')->with(Mockery::on(function ($twilio) {
             return  $twilio() instanceof Twilio;
         }))->once();
+
+        $this->app->shouldReceive('bind')->with(TwilioService::class, Mockery::on(function ($twilio) {
+            return  $twilio() instanceof TwilioService;
+        }))->once()->andReturn($this->app);
 
         $this->provider->boot();
     }


### PR DESCRIPTION
Fixed this issue https://github.com/laravel-notification-channels/twilio/issues/20#issuecomment-281202424

Sorry about that, not sure how I had it working before.

It is because the make() method on the container can no longer take additional parameters