### PR TITLE
Allows messaging service to be submitted without from number

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Twilio;
 
-use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
 use Twilio\Rest\Client as TwilioService;
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
 
 class Twilio
 {
@@ -72,7 +72,7 @@ class Twilio
             $params['messagingServiceSid'] = $serviceSid;
         }
 
-        if (!isset($params['messagingServiceSid'])) {
+        if (! isset($params['messagingServiceSid'])) {
             $params['from'] = $this->getFrom($message);
         }
 

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -65,12 +65,15 @@ class Twilio
     protected function sendSmsMessage(TwilioSmsMessage $message, $to)
     {
         $params = [
-            'from' => $this->getFrom($message),
             'body' => trim($message->content),
         ];
 
         if ($serviceSid = $this->config->getServiceSid()) {
             $params['messagingServiceSid'] = $serviceSid;
+        }
+
+        if (!isset($params['messagingServiceSid'])) {
+            $params['from'] = $this->getFrom($message);
         }
 
         return $this->twilioService->messages->create($to, $params);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -72,7 +72,6 @@ class IntegrationTest extends MockeryTestCase
         $channel = new TwilioChannel($twilio, $this->events);
 
         $this->smsMessageWillBeSentToTwilioWith('+22222222222', [
-            'from' => '+31612345678',
             'body' => 'Message text',
             'messagingServiceSid' => '0123456789',
         ]);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,18 +2,18 @@
 
 namespace NotificationChannels\Twilio\Test;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Notifications\Notification;
 use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use NotificationChannels\Twilio\TwilioCallMessage;
-use NotificationChannels\Twilio\TwilioChannel;
-use NotificationChannels\Twilio\TwilioConfig;
-use NotificationChannels\Twilio\TwilioSmsMessage;
 use NotificationChannels\Twilio\Twilio;
 use Twilio\Rest\Client as TwilioService;
-use Twilio\Rest\Api\V2010\Account\MessageList;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Events\Dispatcher;
 use Twilio\Rest\Api\V2010\Account\CallList;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use NotificationChannels\Twilio\TwilioConfig;
+use NotificationChannels\Twilio\TwilioChannel;
+use Twilio\Rest\Api\V2010\Account\MessageList;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use NotificationChannels\Twilio\TwilioCallMessage;
 
 class IntegrationTest extends MockeryTestCase
 {

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -2,18 +2,18 @@
 
 namespace NotificationChannels\Twilio\Test;
 
-use Illuminate\Contracts\Events\Dispatcher;
 use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
-use NotificationChannels\Twilio\TwilioConfig;
-use NotificationChannels\Twilio\TwilioMessage;
-use NotificationChannels\Twilio\TwilioCallMessage;
-use NotificationChannels\Twilio\TwilioSmsMessage;
-use NotificationChannels\Twilio\Twilio;
 use Services_Twilio_Rest_Calls;
 use Services_Twilio_Rest_Messages;
+use NotificationChannels\Twilio\Twilio;
 use Twilio\Rest\Client as TwilioService;
+use Illuminate\Contracts\Events\Dispatcher;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use NotificationChannels\Twilio\TwilioConfig;
+use NotificationChannels\Twilio\TwilioMessage;
+use NotificationChannels\Twilio\TwilioSmsMessage;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use NotificationChannels\Twilio\Exceptions\CouldNotSendNotification;
 
 class TwilioTest extends MockeryTestCase
 {

--- a/tests/TwilioTest.php
+++ b/tests/TwilioTest.php
@@ -100,10 +100,6 @@ class TwilioTest extends MockeryTestCase
     {
         $message = new TwilioSmsMessage('Message text');
 
-        $this->config->shouldReceive('getFrom')
-            ->once()
-            ->andReturn('+1234567890');
-
         $this->config->shouldReceive('getServiceSid')
             ->once()
             ->andReturn('service_sid');
@@ -111,7 +107,6 @@ class TwilioTest extends MockeryTestCase
         $this->twilioService->messages->shouldReceive('create')
             ->atLeast()->once()
             ->with('+1111111111', [
-                'from' => '+1234567890',
                 'body' => 'Message text',
                 'messagingServiceSid' => 'service_sid',
             ])
@@ -147,6 +142,10 @@ class TwilioTest extends MockeryTestCase
         $smsMessage = new TwilioSmsMessage('Message text');
 
         $this->config->shouldReceive('getFrom')
+            ->once()
+            ->andReturn(null);
+
+        $this->config->shouldReceive('getServiceSid')
             ->once()
             ->andReturn(null);
 


### PR DESCRIPTION
When using the Co-Pilot features with a messaging service things like sticky senders would not work the way this package currently handling sms configuration.

This pull request updates the `sendSmsMessage` method to only append the `from` key if a `messagingServiceSid` is not present.

If this does work already and is simply a manner of out of date documentation then I apologize, but I could not get it to work personally while attempting to use Co-Pilot. The reason I believe this is the proper fix is that in their documentation (in the code examples) they show creating messages by only passing the `messageServiceSid` and the `body` without the `from` key.

Thanks for taking the time to review this PR.