### PR TITLE
Updated to support Laravel 5.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twilio notifications channel for Laravel 5.3
+# Twilio notifications channel for Laravel 5.3+
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/twilio.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/twilio)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.5.9",
         "twilio/sdk": "^5.4.1",
-        "illuminate/notifications": "5.1.*|5.2.*|5.3.*|5.4.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*",
-        "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*",
-        "illuminate/queue": "5.1.*|5.2.*|5.3.*|5.4.*"
+        "illuminate/notifications": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/queue": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
We're looking to use this package on Laravel 5.5, but the current dependency requirements are preventing us. This fixes that.