### PR TITLE
Updated config names to match TwilioService. Added ability to explici…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Add your Twilio Account SID, Auth Token, and From Number (optional) to your `con
 // config/services.php
 ...
 'twilio' => [
-    'account_sid' => env('TWILIO_ACCOUNT_SID'),
-    'auth_token' => env('TWILIO_AUTH_TOKEN'),
+    'username' => env('TWILIO_USERNAME'),
+    'password' => env('TWILIO_PASSWORD'),
+    'account_sid' => env('TWILIO_ACCOUNT_SID'), //optional
     'from' => env('TWILIO_FROM'), // optional
 ],
 ...

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -19,6 +19,26 @@ class TwilioConfig
         $this->config = $config;
     }
 
+	/**
+	 * Get the username.
+	 *
+	 * @return string
+	 */
+	public function getUsername()
+    {
+    	return $this->config['username'];
+    }
+
+	/**
+	 * Get the password.
+	 *
+	 * @return string
+	 */
+	public function getPassword()
+    {
+    	return $this->config['password'];
+    }
+
     /**
      * Get the account sid.
      *
@@ -27,16 +47,6 @@ class TwilioConfig
     public function getAccountSid()
     {
         return $this->config['account_sid'];
-    }
-
-    /**
-     * Get the auth token.
-     *
-     * @return string
-     */
-    public function getAuthToken()
-    {
-        return $this->config['auth_token'];
     }
 
     /**

--- a/src/TwilioProvider.php
+++ b/src/TwilioProvider.php
@@ -23,7 +23,7 @@ class TwilioProvider extends ServiceProvider
 
         $this->app->bind(TwilioService::class, function () {
             $config = $this->app['config']['services.twilio'];
-            return new TwilioService($config['account_sid'], $config['auth_token']);
+            return new TwilioService($config['username'], $config['password'], $config['account_sid']);
         });
     }
 


### PR DESCRIPTION
I ran across this issue when trying to use a sub-account with an API key in Twilio. After a lot of confusion and back and forth with their support, i got it to work when using the standard PHP SDK that they provide. 

When using an API key, you must provide the Account SID, API Key, and API Secret. All 3 can be passed into the RestClient as seen below.
```php
$accountSid = 'ACf54ecc1c1becbe782a63f7ffXXXXXXXX';
$username = 'SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'; // (API Key)
$password = 'your_api_secret'; // (API Secret)
$client = new Client($username, $password, $accountSid);
```
This library doesn't support this because of the explicit usage of the Account SID. When not using API Keys the username is just your Account SID. 

Currently the naming conventions for the configuration items can lead to a lot of confusion when debugging as the Twilio library uses username, password, and accountSid. This PR unifies naming of parameters / config items to make things easier to understand. 
```php
'twilio' => [
    'username' => env('TWILIO_USERNAME'),
    'password' => env('TWILIO_PASSWORD'),
    'account_sid' => env('TWILIO_ACCOUNT_SID'), // optional
    'from' => env('TWILIO_FROM'), // optional
],
```
I know that this is a breaking change as the account_sid is being used as "username" currently. I'm open to other ideas, however logically it just seems to make sense to match Twilio in the long run?
