### PR TITLE
Adding Laravel 5.6 to allowed versions of Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.5.9",
         "twilio/sdk": "^5.4.1",
-        "illuminate/notifications": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/queue": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
+        "illuminate/notifications": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/events": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/queue": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Tests all pass with Laravel 5.6