### PR TITLE
Rethrow exception so that job status is handled

### DIFF
--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -63,6 +63,9 @@ class TwilioChannel
             } else {
                 $this->events->fire($event);
             }
+
+            // Rethrow exception so that job status is handled
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
Closes laravel-notification-channels/twilio#60