### PR TITLE
Adding optional force delivery to TwilioSmsMessage

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -84,6 +84,7 @@ class Twilio
             'statusCallback',
             'statusCallbackMethod',
             'applicationSid',
+            'forceDelivery',
             'maxPrice',
             'provideFeedback',
             'validityPeriod',

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -20,6 +20,11 @@ class TwilioSmsMessage extends TwilioMessage
     public $applicationSid = null;
 
     /**
+     * @var null|bool
+     */
+    public $forceDelivery = null;
+
+    /**
      * @var null|float
      */
     public $maxPrice = null;
@@ -95,6 +100,19 @@ class TwilioSmsMessage extends TwilioMessage
     public function applicationSid($applicationSid)
     {
         $this->applicationSid = $applicationSid;
+
+        return $this;
+    }
+
+    /**
+     * Set force delivery (Deliver message without validation).
+     *
+     * @param bool $forceDelivery
+     * @return $this
+     */
+    public function forceDelivery($forceDelivery)
+    {
+        $this->forceDelivery = $forceDelivery;
 
         return $this;
     }

--- a/tests/TwilioMmsMessageTest.php
+++ b/tests/TwilioMmsMessageTest.php
@@ -63,6 +63,7 @@ class TwilioMmsMessageTest extends TwilioMessageTest
         $message->statusCallback('http://example.com');
         $message->statusCallbackMethod('PUT');
         $message->applicationSid('ABCD1234');
+        $message->forceDelivery(true);
         $message->maxPrice(0.05);
         $message->provideFeedback(true);
         $message->validityPeriod(120);
@@ -71,6 +72,7 @@ class TwilioMmsMessageTest extends TwilioMessageTest
         $this->assertEquals('http://example.com', $message->statusCallback);
         $this->assertEquals('PUT', $message->statusCallbackMethod);
         $this->assertEquals('ABCD1234', $message->applicationSid);
+        $this->assertEquals(true, $message->forceDelivery);
         $this->assertEquals(0.05, $message->maxPrice);
         $this->assertEquals(true, $message->provideFeedback);
         $this->assertEquals(120, $message->validityPeriod);


### PR DESCRIPTION
Had a few issues with their validation saying multiple customers mobile number wasn't a mobile number, even though we can confirm it is. Issue being that their third party checker for phone numbers, isn't up to date with the danish phone number registry, which we don't know how often they will update.

The only way to bypass this is adding the optional parameter forceDelivery, which bypasses their validation and sends it without checking.

