### PR TITLE
Don't fire NotificationSent if we get an error from response

### DIFF
--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -63,6 +63,9 @@ class TwilioChannel
             } else {
                 $this->events->fire($event);
             }
+            
+            // by throwing exception, NotificationSent event is not triggered and we only trigger NotificationFailed above instead
+            throw new \Exception('Notification failed '.$exception->getMessage());
         }
     }
 

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -63,7 +63,7 @@ class TwilioChannel
             } else {
                 $this->events->fire($event);
             }
-            
+
             // by throwing exception, NotificationSent event is not triggered and we only trigger NotificationFailed above instead
             throw new \Exception('Notification failed '.$exception->getMessage());
         }


### PR DESCRIPTION
The TwilioChannel will trigger both events `NotificationSent` and `NotificationFailed` if the Twilio's REST API response is an error, for example a 400 error (bad number, etc).

For me it makes sense if there's an error on the Twilio's REST API response to only fire `NotificationFailed` event and not both.

This modification will throw an exception on the `send` method if we get an error on the Twilio's response and will not trigger the NotificationSend event.