### PR TITLE
documentation: service sid config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ TWILIO_ACCOUNT_SID=1234 # always required
 TWILIO_FROM=100000000 # optional default from
 TWILIO_ALPHA_SENDER=HELLO # optional
 TWILIO_DEBUG_TO=23423423423 # Set a number that call calls/messages should be routed to for debugging
-TWILIO_SMS_SERVICE_SID=MG0a0aaaaaa00aa00a00a000a00000a00a # Optional. Recommended when sending globally
+TWILIO_SMS_SERVICE_SID=MG0a0aaaaaa00aa00a00a000a00000a00a # Optional but recommended 
 ```
 
 ### Advanced configuration

--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ exception codes from [the documentation](https://www.twilio.com/docs/api/errors)
 If you want to suppress all errors, you can set the option to `['*']`. The errors will not be logged but notification
 failed events will still be emitted.
 
-#### Global SMS
+#### Recommended Configuration
 
-If you plan to send SMS globally then it's a good idea to set up a (Messaging Service)[https://www.twilio.com/docs/sms/services]. 
-These abstracts the configuration of sending SMS and handles picking a phone number out of a pool instead of explicitly mentioning 
-the from or alphanumeric sender.
+Twilio recommends always using a [Messaging Service](https://www.twilio.com/docs/sms/services) because it gives you
+ access to features like Advanced Opt-Out, Sticky Sender, Scaler, Geomatch, Shortcode Reroute, and Smart Encoding.
+
+Having issues with SMS? Check Twilio's [best practices](https://www.twilio.com/docs/sms/services/services-best-practices).
 
 ## Upgrading from 2.x to 3.x
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ TWILIO_ACCOUNT_SID=1234 # always required
 TWILIO_FROM=100000000 # optional default from
 TWILIO_ALPHA_SENDER=HELLO # optional
 TWILIO_DEBUG_TO=23423423423 # Set a number that call calls/messages should be routed to for debugging
+TWILIO_SMS_SERVICE_SID=MG0d3dbdaef37df66fcea700e60695c52a # Optional. Recommended when sending globally
 ```
 
 ### Advanced configuration
@@ -161,11 +162,21 @@ public function routeNotificationForTwilio()
 
 - `from('')`: Accepts a phone to use as the notification sender.
 - `content('')`: Accepts a string value for the notification body.
+- `messagingServiceSid('')`: Accepts a messaging service SID to handle configuration.
 
 #### TwilioCallMessage
 
 - `from('')`: Accepts a phone to use as the notification sender.
 - `url('')`: Accepts an url for the call TwiML.
+
+### Global SMS
+
+If you plan to send SMS globally then it's a good idea to set up a (Messaging Service)[https://www.twilio.com/docs/sms/services]. 
+These abstracts the configuration of sending SMS and handles picking a the phone number out of a pool instead of explicitly mentioning 
+a from or alphanumeric sender.
+
+If you are using a single messaging service make sure you have the `TWILIO_FROM` and `TWILIO_ALPHA_SENDER` empty while providing a
+ `TWILIO_SMS_SERVICE_SID`. Otherwise conditionally set the `messagingServiceSid` on the `TwilioSmsMessage`.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ public function routeNotificationForTwilio()
 - `from('')`: Accepts a phone to use as the notification sender.
 - `url('')`: Accepts an url for the call TwiML.
 
-
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ If you plan to send SMS globally then it's a good idea to set up a (Messaging Se
 These abstracts the configuration of sending SMS and handles picking a phone number out of a pool instead of explicitly mentioning 
 the from or alphanumeric sender.
 
-If you are using a single messaging service make sure you have the `TWILIO_FROM` and `TWILIO_ALPHA_SENDER` empty while providing a
- `TWILIO_SMS_SERVICE_SID`. Otherwise conditionally set the `messagingServiceSid` on the `TwilioSmsMessage`.
-
-
 ## Upgrading from 2.x to 3.x
 
 If you're upgrading from version `2.x`, you'll need to make sure that your set environment variables match those above 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ TWILIO_ACCOUNT_SID=1234 # always required
 TWILIO_FROM=100000000 # optional default from
 TWILIO_ALPHA_SENDER=HELLO # optional
 TWILIO_DEBUG_TO=23423423423 # Set a number that call calls/messages should be routed to for debugging
-TWILIO_SMS_SERVICE_SID=MG0d3dbdaef37df66fcea700e60695c52a # Optional. Recommended when sending globally
+TWILIO_SMS_SERVICE_SID=MG0a0aaaaaa00aa00a00a000a00000a00a # Optional. Recommended when sending globally
 ```
 
 ### Advanced configuration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ You are viewing the `3.x` documentation. [Click here](https://github.com/laravel
 ## Contents
 
 - [Installation](#installation)
-	- [Setting up your Twilio account](#setting-up-your-twilio-account)
 - [Usage](#usage)
 	- [Available Message methods](#available-message-methods)
 - [Changelog](#changelog)
@@ -62,6 +61,16 @@ exception codes from [the documentation](https://www.twilio.com/docs/api/errors)
 
 If you want to suppress all errors, you can set the option to `['*']`. The errors will not be logged but notification
 failed events will still be emitted.
+
+#### Global SMS
+
+If you plan to send SMS globally then it's a good idea to set up a (Messaging Service)[https://www.twilio.com/docs/sms/services]. 
+These abstracts the configuration of sending SMS and handles picking a phone number out of a pool instead of explicitly mentioning 
+the from or alphanumeric sender.
+
+If you are using a single messaging service make sure you have the `TWILIO_FROM` and `TWILIO_ALPHA_SENDER` empty while providing a
+ `TWILIO_SMS_SERVICE_SID`. Otherwise conditionally set the `messagingServiceSid` on the `TwilioSmsMessage`.
+
 
 ## Upgrading from 2.x to 3.x
 
@@ -169,14 +178,6 @@ public function routeNotificationForTwilio()
 - `from('')`: Accepts a phone to use as the notification sender.
 - `url('')`: Accepts an url for the call TwiML.
 
-### Global SMS
-
-If you plan to send SMS globally then it's a good idea to set up a (Messaging Service)[https://www.twilio.com/docs/sms/services]. 
-These abstracts the configuration of sending SMS and handles picking a phone number out of a pool instead of explicitly mentioning 
-the from or alphanumeric sender.
-
-If you are using a single messaging service make sure you have the `TWILIO_FROM` and `TWILIO_ALPHA_SENDER` empty while providing a
- `TWILIO_SMS_SERVICE_SID`. Otherwise conditionally set the `messagingServiceSid` on the `TwilioSmsMessage`.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ public function routeNotificationForTwilio()
 ### Global SMS
 
 If you plan to send SMS globally then it's a good idea to set up a (Messaging Service)[https://www.twilio.com/docs/sms/services]. 
-These abstracts the configuration of sending SMS and handles picking a the phone number out of a pool instead of explicitly mentioning 
-a from or alphanumeric sender.
+These abstracts the configuration of sending SMS and handles picking a phone number out of a pool instead of explicitly mentioning 
+the from or alphanumeric sender.
 
 If you are using a single messaging service make sure you have the `TWILIO_FROM` and `TWILIO_ALPHA_SENDER` empty while providing a
  `TWILIO_SMS_SERVICE_SID`. Otherwise conditionally set the `messagingServiceSid` on the `TwilioSmsMessage`.

--- a/config/twilio-notification-channel.php
+++ b/config/twilio-notification-channel.php
@@ -10,7 +10,7 @@ return [
     'alphanumeric_sender' => env('TWILIO_ALPHA_SENDER'),
 
     /**
-     * See https://www.twilio.com/docs/sms/services
+     * See https://www.twilio.com/docs/sms/services.
      */
     'sms_service_sid' => env('TWILIO_SMS_SERVICE_SID'),
 

--- a/config/twilio-notification-channel.php
+++ b/config/twilio-notification-channel.php
@@ -10,6 +10,11 @@ return [
     'alphanumeric_sender' => env('TWILIO_ALPHA_SENDER'),
 
     /**
+     * See https://www.twilio.com/docs/sms/services
+     */
+    'sms_service_sid' => env('TWILIO_SMS_SERVICE_SID'),
+
+    /**
      * Specify a number where all calls/messages should be routed. This can be used in development/staging environments
      * for testing.
      */


### PR DESCRIPTION
As far as I could tell the logic for handling `sms_service_sid` is already working. The README was just missing how to use it. 

Twilio recommends that SMS be set up with a messaging service, so I've updated the documentation to try and steer people towards that.

Oh, also there was a broken link in the readme regarding setting up a Twilio account, not sure if this was intentional?

