### PR TITLE
Allow anonymous notifiables using class name

### DIFF
--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -85,6 +85,9 @@ class TwilioChannel
      */
     protected function getTo($notifiable)
     {
+        if ($notifiable->routeNotificationFor(self::class)) {
+            return $notifiable->routeNotificationFor(self::class);
+        }
         if ($notifiable->routeNotificationFor('twilio')) {
             return $notifiable->routeNotificationFor('twilio');
         }


### PR DESCRIPTION
Sending using a class name isn't documented anywhere: all documentation examples use short names. However, the class name may be a less ambiguous identifier. Resolves #58