### PR TITLE
Twiml voice calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ class AccountApproved extends Notification
 }
 ```
 
-Or create a Twilio call:
+Or create a Twilio call, using either an external TwiML url:
 
 ``` php
 use NotificationChannels\Twilio\TwilioChannel;
@@ -149,6 +149,32 @@ class AccountApproved extends Notification
     {
         return (new TwilioCallMessage())
             ->url("http://example.com/your-twiml-url");
+    }
+}
+```
+
+Or create a Twilio call, and send a TwiML response directly:
+
+``` php
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioCallMessage;
+use Illuminate\Notifications\Notification;
+use Twilio\TwiML\VoiceResponse;
+
+class AccountApproved extends Notification
+{
+    public function via($notifiable)
+    {
+        return [TwilioChannel::class];
+    }
+
+    public function toTwilio($notifiable)
+    {
+        return (new TwilioCallMessage())
+            ->twiml(
+                (new VoiceResponse())
+                    ->say('Hello world')
+            );
     }
 }
 ```
@@ -174,6 +200,9 @@ public function routeNotificationForTwilio()
 
 - `from('')`: Accepts a phone to use as the notification sender.
 - `url('')`: Accepts an url for the call TwiML.
+- `twiml(VoiceResponse)`: Accepts a \Twilio\TwiML\VoiceResponse containing the call TwiML.
+
+> You can use *either* url() *or* twiml() on a TwilioCallMessage object, not both.
 
 ## Changelog
 

--- a/src/Exceptions/InvalidConfigException.php
+++ b/src/Exceptions/InvalidConfigException.php
@@ -10,4 +10,9 @@ class InvalidConfigException extends \Exception
     {
         return new self('Missing config. You must set either the username & password or SID and auth token');
     }
+
+    public static function multipleContentTypes(): self
+    {
+        return new self('Unable to use URL and TWIML call types simultaneously. You can use only one type');
+    }
 }

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -116,7 +116,7 @@ class Twilio
     protected function makeCall(TwilioCallMessage $message, ?string $to): CallInstance
     {
         $params = [
-            'url' => trim($message->content),
+            $message->contentType => trim($message->content),
         ];
 
         $this->fillOptionalParams($params, $message, [

--- a/src/TwilioCallMessage.php
+++ b/src/TwilioCallMessage.php
@@ -69,7 +69,7 @@ class TwilioCallMessage extends TwilioMessage
     protected function contentType(string $contentType)
     {
         if (
-            !is_null($this->contentType)
+            ! is_null($this->contentType)
             && $contentType !== $this->contentType
         ) {
             InvalidConfigException::multipleContentTypes();

--- a/src/TwilioCallMessage.php
+++ b/src/TwilioCallMessage.php
@@ -2,10 +2,21 @@
 
 namespace NotificationChannels\Twilio;
 
+use NotificationChannels\Twilio\Exceptions\InvalidConfigException;
+use Twilio\TwiML\VoiceResponse;
+
 class TwilioCallMessage extends TwilioMessage
 {
     public const STATUS_CANCELED = 'canceled';
     public const STATUS_COMPLETED = 'completed';
+
+    public const TYPE_URL = 'url';
+    public const TYPE_TWIML = 'twiml';
+
+    /**
+     * @var int
+     */
+    public $contentType = null;
 
     /**
      * @var null|string
@@ -35,9 +46,36 @@ class TwilioCallMessage extends TwilioMessage
      */
     public function url(string $url): self
     {
+        $this->contentType(self::TYPE_URL);
         $this->content = $url;
 
         return $this;
+    }
+
+    /**
+     * Set the message twiml.
+     *
+     * @param  string $twiml
+     * @return $this
+     */
+    public function twiml(VoiceResponse $response): self
+    {
+        $this->contentType(self::TYPE_TWIML);
+        $this->content = (string) $response;
+
+        return $this;
+    }
+
+    protected function contentType(string $contentType)
+    {
+        if (
+            !is_null($this->contentType)
+            && $contentType !== $this->contentType
+        ) {
+            InvalidConfigException::multipleContentTypes();
+        }
+
+        $this->contentType = $contentType;
     }
 
     /**


### PR DESCRIPTION
Twilio now supports sending TwiML along with the initial request to create a call, rather than needing an external url to fetch TwiML from. It would be nice to support this alongside the existing url() method.

https://www.twilio.com/docs/voice/tutorials/how-to-make-outbound-phone-calls-php

### Example use case:
You have a system which you want to be able to send a text-based notification to a phone.
i.e. `call a phone -> read out a message -> then hang up`.

This can now be achieved by sending the message directly from the laravel notification, the same way you would a SMS, instead of also needing to handle urls and routing. It leaves open the whole TwiML flexibilty for more complex call chains by accepting an instance of VoiceResponse.

Previously this would be difficult for a system which didn't allow incoming network requests from the net, especially those behind a firewall, since you potentially need an entirely different system would need to handle the TwiML url responses.

---

### Tests

I've been struggling to get the *existing unit tests* to pass `Error: Class 'Orchestra\Testbench\TestCase' not found` (I have run `composer install`. Will add new ones when I get past this. EDIT: So it seems github-actions doesn't get that message, so must be something on my local box. I'll take another go at it over the weekend. Any thoughts still appreciated! :)

I've opened this PR to get comments while I finish it off. There are several ways it could be implemented & happy to adjust to your style if that's preferred.