### PR TITLE
Support for Optional Parameter Attempt & SmartEncoded in SmsMessage

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -92,6 +92,11 @@ class Twilio
             'maxPrice',
             'provideFeedback',
             'validityPeriod',
+            'attempt',
+            'contentRetention',
+            'addressRetention',
+            'smartEncoded',
+            'persistentAction',
         ]);
 
         if ($message instanceof TwilioMmsMessage) {

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -93,10 +93,7 @@ class Twilio
             'provideFeedback',
             'validityPeriod',
             'attempt',
-            'contentRetention',
-            'addressRetention',
             'smartEncoded',
-            'persistentAction',
         ]);
 
         if ($message instanceof TwilioMmsMessage) {

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -41,11 +41,14 @@ class TwilioSmsMessage extends TwilioMessage
 
     /**
      * @var null|int
+     * Total number of attempts made ( including this ) to send out the message regardless of the provider used.
+     * Used to provide feedback of delivery quality to twilio.
      */
     public $attempt;
 
     /**
      * @var null|bool
+     * Whether to detect Unicode characters that have a similar GSM-7 character and replace them.
      */
     public $smartEncoded;
 

--- a/src/TwilioSmsMessage.php
+++ b/src/TwilioSmsMessage.php
@@ -40,6 +40,16 @@ class TwilioSmsMessage extends TwilioMessage
     public $validityPeriod;
 
     /**
+     * @var null|int
+     */
+    public $attempt;
+
+    /**
+     * @var null|bool
+     */
+    public $smartEncoded;
+
+    /**
      * Get the from address of this message.
      *
      * @return null|string
@@ -149,12 +159,37 @@ class TwilioSmsMessage extends TwilioMessage
      * Set the validity period (in seconds).
      *
      * @param int $validityPeriodSeconds
-     *
      * @return $this
      */
     public function validityPeriod(int $validityPeriodSeconds): self
     {
         $this->validityPeriod = $validityPeriodSeconds;
+
+        return $this;
+    }
+
+    /**
+     * Set the attempt option.
+     *
+     * @param int $attempt
+     * @return $this
+     */
+    public function attempt(int $attempt): self
+    {
+        $this->attempt = $attempt;
+
+        return $this;
+    }
+
+    /**
+     * Set the smart encoded option.
+     *
+     * @param bool $smartEncoded
+     * @return $this
+     */
+    public function smartEncoded(bool $smartEncoded): self
+    {
+        $this->smartEncoded = $smartEncoded;
 
         return $this;
     }

--- a/tests/Unit/TwilioSmsMessageTest.php
+++ b/tests/Unit/TwilioSmsMessageTest.php
@@ -57,6 +57,8 @@ class TwilioSmsMessageTest extends TwilioMessageTest
         $message->maxPrice(0.05);
         $message->provideFeedback(true);
         $message->validityPeriod(120);
+        $message->attempt(5);
+        $message->smartEncoded(true);
 
         $this->assertEquals('http://example.com', $message->statusCallback);
         $this->assertEquals('PUT', $message->statusCallbackMethod);
@@ -64,5 +66,7 @@ class TwilioSmsMessageTest extends TwilioMessageTest
         $this->assertEquals(0.05, $message->maxPrice);
         $this->assertEquals(true, $message->provideFeedback);
         $this->assertEquals(120, $message->validityPeriod);
+        $this->assertEquals(5, $message->attempt);
+        $this->assertEquals(true, $message->smartEncoded);
     }
 }


### PR DESCRIPTION
The Twilio Api understands more optional parameters than this package provides. I was able to test Attempt & SmartEncoded in SmsMessage, so those are added in this pull request. 

https://www.twilio.com/docs/sms/api/message-resource?code-sample=code-delete-message&code-language=twilio-cli&code-sdk-version=1.x#create-a-message-resource