### PR TITLE
Twilio customized to phone number

### DIFF
--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -91,6 +91,9 @@ class TwilioChannel
         if ($message->getTo()) {
             return $message->getTo();
         }
+        if ($notifiable->routeNotificationFor(self::class, $notification)) {
+            return $notifiable->routeNotificationFor(self::class, $notification);
+        }
         if ($notifiable->routeNotificationFor('twilio', $notification)) {
             return $notifiable->routeNotificationFor('twilio', $notification);
         }

--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -44,9 +44,7 @@ class TwilioChannel
     public function send($notifiable, Notification $notification)
     {
         try {
-            $to = $this->getTo($notifiable, $notification);
             $message = $notification->toTwilio($notifiable);
-            $useSender = $this->canReceiveAlphanumericSender($notifiable);
 
             if (is_string($message)) {
                 $message = new TwilioSmsMessage($message);
@@ -55,6 +53,9 @@ class TwilioChannel
             if (! $message instanceof TwilioMessage) {
                 throw CouldNotSendNotification::invalidMessageObject($message);
             }
+
+            $to = $this->getTo($notifiable, $notification, $message);
+            $useSender = $this->canReceiveAlphanumericSender($notifiable);
 
             return $this->twilio->sendMessage($message, $to, $useSender);
         } catch (Exception $exception) {
@@ -79,15 +80,16 @@ class TwilioChannel
      * Get the address to send a notification to.
      *
      * @param mixed $notifiable
-     * @param Notification|null $notification
+     * @param Notification $notification
+     * @param TwilioMessage $message
      *
      * @return mixed
      * @throws CouldNotSendNotification
      */
-    protected function getTo($notifiable, $notification = null)
+    protected function getTo($notifiable, $notification, $message)
     {
-        if ($notifiable->routeNotificationFor(self::class, $notification)) {
-            return $notifiable->routeNotificationFor(self::class, $notification);
+        if ($message->getTo()) {
+            return $message->getTo();
         }
         if ($notifiable->routeNotificationFor('twilio', $notification)) {
             return $notifiable->routeNotificationFor('twilio', $notification);

--- a/src/TwilioMessage.php
+++ b/src/TwilioMessage.php
@@ -17,6 +17,14 @@ abstract class TwilioMessage
      * @var string
      */
     public $from;
+    
+    /**
+     * The phone number the message should be sent to.
+     * This is optional. If available, will override $notifiable phone number
+     *
+     * @var string
+     */
+    public $to;
 
     /**
      * @var null|string
@@ -82,6 +90,29 @@ abstract class TwilioMessage
     public function getFrom(): ?string
     {
         return $this->from;
+    }
+    
+    /**
+     * Set the phone number the message should be sent to.
+     *
+     * @param  string $to
+     * @return $this
+     */
+    public function to(string $to): self
+    {
+        $this->to = $to;
+
+        return $this;
+    }
+
+    /**
+     * Get the to address.
+     *
+     * @return string|null
+     */
+    public function getTo(): ?string
+    {
+        return $this->to;
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/laravel-notification-channels/twilio/issues/118

To() method will allow developers to add phone numbers dynamically from the notification itself. If the user needs to use different phone numbers for different notifications, it will help a lot.

This is just to check if any recipient number is provided in the message itself. If provided, this means the developer wants to override the notifiable user's phone number.
And if not overridden, then we can safely use the notifiable's phone number as it was before.