### PR TITLE
Consider "" value for TWILIO_DEBUG_TO as null

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -64,7 +64,7 @@ class Twilio
     {
         $debugTo = $this->config->getDebugTo();
 
-        if ($debugTo !== null && $debugTo !== "") {
+        if (!empty($debugTo)) {
             $to = $debugTo;
         }
 

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -64,7 +64,7 @@ class Twilio
     {
         $debugTo = $this->config->getDebugTo();
 
-        if ($debugTo !== null) {
+        if ($debugTo !== null && $debugTo !== "") {
             $to = $debugTo;
         }
 


### PR DESCRIPTION
If a user has defined `TWILIO_DEBUG_TO=` in .env then it should also be considered as `NULL`.
Before this change `$debugTo` was being set to `""` (`strlen($debugTo) = 0`).
This change will prevent this unexpected behavior.