### PR TITLE
Include debug_to option on making calls

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -115,6 +115,12 @@ class Twilio
      */
     protected function makeCall(TwilioCallMessage $message, ?string $to): CallInstance
     {
+        $debugTo = $this->config->getDebugTo();
+
+        if ($debugTo !== null) {
+            $to = $debugTo;
+        }
+
         $params = [
             'url' => trim($message->content),
         ];


### PR DESCRIPTION
Right now, only the SMS method uses the debug_to config even though the docs mention otherwise. This just includes the option for calls.