### PR TITLE
Suppress notification if notifier address is NULL

### DIFF
--- a/src/TwilioChannel.php
+++ b/src/TwilioChannel.php
@@ -45,6 +45,10 @@ class TwilioChannel
     {
         try {
             $to = $this->getTo($notifiable, $notification);
+            
+            // Suppress notification if notifier address is found to be NULL
+            if($to === null) return;
+            
             $message = $notification->toTwilio($notifiable);
             $useSender = $this->canReceiveAlphanumericSender($notifiable);
 


### PR DESCRIPTION
Other drivers allows notification suppression by returning null from route methods This driver can provide same functionality as well