### PR TITLE
Add option to use Twilio's URL shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ TWILIO_ACCOUNT_SID=1234 # always required
 TWILIO_FROM=100000000 # optional default from
 TWILIO_ALPHA_SENDER=HELLO # optional
 TWILIO_DEBUG_TO=23423423423 # Set a number that call calls/messages should be routed to for debugging
-TWILIO_SMS_SERVICE_SID=MG0a0aaaaaa00aa00a00a000a00000a00a # Optional but recommended 
+TWILIO_SMS_SERVICE_SID=MG0a0aaaaaa00aa00a00a000a00000a00a # Optional but recommended
+TWILIO_SHORTEN_URLS=true # optional, enable URL shortener
 ```
 
 ### Advanced configuration

--- a/config/twilio-notification-channel.php
+++ b/config/twilio-notification-channel.php
@@ -8,6 +8,7 @@ return [
 
     'from' => env('TWILIO_FROM'), // optional
     'alphanumeric_sender' => env('TWILIO_ALPHA_SENDER'),
+    'shorten_urls' => env('TWILIO_SHORTEN_URLS', false), // optional, enable twilio URL shortener
 
     /**
      * See https://www.twilio.com/docs/sms/services.

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -76,6 +76,10 @@ class Twilio
             $params['messagingServiceSid'] = $messagingServiceSid;
         }
 
+        if ($this->config->isShortenUrlsEnabled()) {
+            $params['ShortenUrls'] = "true";
+        }
+
         if ($from = $this->getFrom($message)) {
             $params['from'] = $from;
         }

--- a/src/TwilioConfig.php
+++ b/src/TwilioConfig.php
@@ -78,4 +78,9 @@ class TwilioConfig
 
         return in_array($code, $this->getIgnoredErrorCodes(), true);
     }
+
+    public function isShortenUrlsEnabled(): bool
+    {
+        return $this->config['shorten_urls'] ?? false;
+    }
 }

--- a/tests/Unit/IntegrationTest.php
+++ b/tests/Unit/IntegrationTest.php
@@ -83,6 +83,28 @@ class IntegrationTest extends MockeryTestCase
     }
 
     /** @test */
+    public function it_can_send_a_sms_message_using_url_shortener()
+    {
+        $message = TwilioSmsMessage::create('Message text');
+        $this->notification->shouldReceive('toTwilio')->andReturn($message);
+
+        $config = new TwilioConfig([
+            'from' => '+31612345678',
+            'ShortenUrls' => true,
+        ]);
+        $twilio = new Twilio($this->twilioService, $config);
+        $channel = new TwilioChannel($twilio, $this->events);
+
+        $this->smsMessageWillBeSentToTwilioWith('+22222222222', [
+            'from' => '+31612345678',
+            'body' => 'Message text',
+            'ShortenUrls' => 'true',
+        ]);
+
+        $channel->send(new NotifiableWithAttribute(), $this->notification);
+    }
+
+    /** @test */
     public function it_can_send_a_sms_message_using_alphanumeric_sender()
     {
         $message = TwilioSmsMessage::create('Message text');


### PR DESCRIPTION
This PR adds the config key `TWILIO_SHORTEN_URLS` to enabled Twilio's URL shortener