### PR TITLE
Added support for content templates (i.e. whatsapp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,32 @@ class AccountApproved extends Notification
 }
 ```
 
+You can also send using Content Templates:
+
+``` php
+use NotificationChannels\Twilio\TwilioChannel;
+use NotificationChannels\Twilio\TwilioContentTemplateMessage;
+use Illuminate\Notifications\Notification;
+
+class AccountApproved extends Notification
+{
+    public function via($notifiable)
+    {
+        return [TwilioChannel::class];
+    }
+
+    public function toTwilio($notifiable)
+    {
+        return (new TwilioContentTemplateMessage())
+            ->contentSid("HXXXXXXXXXXXXXXXXXXXXXXXX")
+            ->contentVariables([
+                '1' => 'John Doe',
+                '2' => 'ACME Inc.',
+            ]);
+    }
+}
+```
+
 Or create a Twilio call:
 
 ``` php

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ class AccountApproved extends Notification
 }
 ```
 
+*Note: if sending via WhatsApp, you must add `whatsapp:` to the beginning of the phone number (i.e. `->from('whatsapp:+61428000382')`). The number must also be approved as a [WhatsApp Sender](https://www.twilio.com/console/sms/whatsapp/senders).*
+
 Or create a Twilio call:
 
 ``` php

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -89,6 +89,13 @@ class Twilio
             ]);
         }
 
+        if ($message instanceof TwilioContentTemplateMessage) {
+            $this->fillOptionalParams($params, $message, [
+                'contentSid',
+                'contentVariables',
+            ]);
+        }
+
         return $this->twilioService->messages->create($to, $params);
     }
 

--- a/src/TwilioContentTemplateMessage.php
+++ b/src/TwilioContentTemplateMessage.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NotificationChannels\Twilio;
+
+class TwilioContentTemplateMessage extends TwilioSmsMessage
+{
+    /**
+     * The SID of the content template (starting with H)
+     * @var null|string
+     */
+    public $contentSid;
+
+    /**
+     * The variables to replace in the content template
+     * @var null|array|string
+     */
+    public $contentVariables;
+
+    /**
+     * Set the content sid (starting with H).
+     *
+     * @param  string $contentSid
+     * @return $this
+     */
+    public function contentSid(string $contentSid): self
+    {
+        $this->contentSid = $contentSid;
+
+        return $this;
+    }
+
+    /**
+     * Set the content variables.
+     *
+     * @param  array $contentVariables The variables to replace in the content template (i.e. ['1' => 'John Doe'])
+     * @return $this
+     */
+    public function contentVariables(array $contentVariables): self
+    {
+        $this->contentVariables = json_encode($contentVariables);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Added support for sending content templates. This also adds support for whatsapp (inherity).

Added documentation about this.

See here for more details: https://www.twilio.com/docs/content/send-templates-created-with-the-content-template-builder#how-to-add-senders-to-a-your-sender-pool