### PR TITLE
Added support for Laravel 12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,16 +37,16 @@
     "require": {
         "php": "^8.2",
         "twilio/sdk": "^7.16 || ^8.3",
-        "illuminate/notifications": "^11.0",
-        "illuminate/support": "^11.0",
-        "illuminate/events": "^11.0",
-        "illuminate/queue": "^11.0"
+        "illuminate/notifications": "^12.0",
+        "illuminate/support": "^12.0",
+        "illuminate/events": "^12.0",
+        "illuminate/queue": "^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^9.0",
-        "phpunit/phpunit": "^10.5"
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/TwilioProviderTest.php
+++ b/tests/Integration/TwilioProviderTest.php
@@ -9,11 +9,12 @@ use NotificationChannels\Twilio\Tests\IntegrationTestCase;
 use NotificationChannels\Twilio\TwilioChannel;
 use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Twilio\Rest\Client;
 
 class TwilioProviderTest extends IntegrationTestCase
 {
-    /** @test */
+    #[Test]
     public function it_cannot_create_the_application_without_config()
     {
         $this->expectException(InvalidConfigException::class);
@@ -21,7 +22,7 @@ class TwilioProviderTest extends IntegrationTestCase
         $this->app->get(TwilioChannel::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_create_the_application_without_sid()
     {
         $this->app['config']->set('twilio-notification-channel.username', 'test');
@@ -31,7 +32,7 @@ class TwilioProviderTest extends IntegrationTestCase
         $this->app->get(TwilioChannel::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_the_application_with_sid()
     {
         $this->app['config']->set('twilio-notification-channel.username', 'test');
@@ -41,7 +42,7 @@ class TwilioProviderTest extends IntegrationTestCase
         $this->assertInstanceOf(TwilioChannel::class, $this->app->get(TwilioChannel::class));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_the_application_with_token_auth()
     {
         $this->app['config']->set('twilio-notification-channel.auth_token', 'token');
@@ -50,7 +51,7 @@ class TwilioProviderTest extends IntegrationTestCase
         $this->assertInstanceOf(TwilioChannel::class, $this->app->get(TwilioChannel::class));
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_three_classes()
     {
         $provides = (new TwilioProvider($this->app))->provides();

--- a/tests/Unit/IntegrationTest.php
+++ b/tests/Unit/IntegrationTest.php
@@ -13,6 +13,7 @@ use NotificationChannels\Twilio\TwilioCallMessage;
 use NotificationChannels\Twilio\TwilioChannel;
 use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit\Framework\Attributes\Test;
 use Twilio\Rest\Api\V2010\Account\CallInstance;
 use Twilio\Rest\Api\V2010\Account\CallList;
 use Twilio\Rest\Api\V2010\Account\MessageInstance;
@@ -42,7 +43,7 @@ class IntegrationTest extends MockeryTestCase
         $this->notification = Mockery::mock(Notification::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message()
     {
         $message = TwilioSmsMessage::create('Message text');
@@ -62,7 +63,7 @@ class IntegrationTest extends MockeryTestCase
         $channel->send(new NotifiableWithAttribute, $this->notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_using_service()
     {
         $message = TwilioSmsMessage::create('Message text');
@@ -84,7 +85,7 @@ class IntegrationTest extends MockeryTestCase
         $channel->send(new NotifiableWithAttribute, $this->notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_using_url_shortener()
     {
         $message = TwilioSmsMessage::create('Message text');
@@ -106,7 +107,7 @@ class IntegrationTest extends MockeryTestCase
         $channel->send(new NotifiableWithAttribute, $this->notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_using_alphanumeric_sender()
     {
         $message = TwilioSmsMessage::create('Message text');
@@ -127,7 +128,7 @@ class IntegrationTest extends MockeryTestCase
         $channel->send(new NotifiableWithAlphanumericSender, $this->notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_make_a_call()
     {
         $message = TwilioCallMessage::create('http://example.com');
@@ -146,7 +147,7 @@ class IntegrationTest extends MockeryTestCase
         $channel->send(new NotifiableWithAttribute, $this->notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_cant_make_a_call_when_the_from_config_is_missing()
     {
         $message = TwilioCallMessage::create('http://example.com');

--- a/tests/Unit/TwilioCallMessageTest.php
+++ b/tests/Unit/TwilioCallMessageTest.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio\Tests\Unit;
 
 use NotificationChannels\Twilio\TwilioCallMessage;
+use PHPUnit\Framework\Attributes\Test;
 
 class TwilioCallMessageTest extends TwilioMessageTestCase
 {
@@ -16,7 +17,7 @@ class TwilioCallMessageTest extends TwilioMessageTestCase
         $this->message = new TwilioCallMessage;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_accept_a_message_when_constructing_a_message()
     {
         $message = new TwilioCallMessage('http://example.com');
@@ -24,7 +25,7 @@ class TwilioCallMessageTest extends TwilioMessageTestCase
         $this->assertEquals('http://example.com', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_a_create_method()
     {
         $message = TwilioCallMessage::create('http://example.com');
@@ -32,7 +33,7 @@ class TwilioCallMessageTest extends TwilioMessageTestCase
         $this->assertEquals('http://example.com', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_the_url()
     {
         $this->message->url('http://example.com');
@@ -40,7 +41,7 @@ class TwilioCallMessageTest extends TwilioMessageTestCase
         $this->assertEquals('http://example.com', $this->message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_optional_parameters()
     {
         $message = TwilioCallMessage::create('myMessage');

--- a/tests/Unit/TwilioChannelTest.php
+++ b/tests/Unit/TwilioChannelTest.php
@@ -13,6 +13,7 @@ use NotificationChannels\Twilio\TwilioCallMessage;
 use NotificationChannels\Twilio\TwilioChannel;
 use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit\Framework\Attributes\Test;
 use Twilio\Exceptions\RestException;
 
 class TwilioChannelTest extends MockeryTestCase
@@ -37,7 +38,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel = new TwilioChannel($this->twilio, $this->dispatcher);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_not_send_a_message_if_not_enabled()
     {
         $notifiable = new Notifiable;
@@ -54,7 +55,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_not_send_a_message_without_known_receiver()
     {
         $notifiable = new Notifiable;
@@ -75,7 +76,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_send_a_sms_message_to_the_result_of_the_route_method_of_the_notifiable()
     {
         $notifiable = new NotifiableWithMethod;
@@ -91,7 +92,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_send_a_sms_message_to_the_result_of_the_route_method_of_the_notifiable_if_it_uses_the_twilio_channel_explicitly()
     {
         $notifiable = new NotifiableWithTwilioChannel;
@@ -107,7 +108,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_make_a_call_to_the_phone_number_attribute_of_the_notifiable()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -123,7 +124,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_convert_a_string_to_a_sms_message()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -138,7 +139,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_fire_an_event_in_case_of_an_invalid_message()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -160,7 +161,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_ignore_specific_error_codes()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -184,7 +185,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_rethrow_non_ignored_error_codes()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -210,7 +211,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_ignore_all_error_codes()
     {
         $notifiable = new NotifiableWithAttribute;
@@ -232,7 +233,7 @@ class TwilioChannelTest extends MockeryTestCase
         $this->channel->send($notifiable, $notification);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_send_using_alphanumeric_if_notifiable_can_receive()
     {
         $notifiable = new NotifiableWithAlphanumericSender;

--- a/tests/Unit/TwilioConfigTest.php
+++ b/tests/Unit/TwilioConfigTest.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio\Tests\Unit;
 
 use NotificationChannels\Twilio\TwilioConfig;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class TwilioConfigTest extends TestCase
@@ -12,7 +13,7 @@ class TwilioConfigTest extends TestCase
         return new TwilioConfig($config);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_boolean_wether_it_is_is_enabled_or_not()
     {
         $this->assertTrue($this->config()->enabled()); // defaults to true
@@ -20,7 +21,7 @@ class TwilioConfigTest extends TestCase
         $this->assertFalse($this->config(['enabled' => false])->enabled());
     }
 
-    /** @test */
+    #[Test]
     public function it_defaults_to_null_for_config_keys_with_a_string_return_type()
     {
         $config = $this->config();
@@ -35,7 +36,7 @@ class TwilioConfigTest extends TestCase
         $this->assertNull($config->getDebugTo());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_string_for_config_keys_with_a_string_return_type()
     {
         $config = $this->config([
@@ -59,14 +60,14 @@ class TwilioConfigTest extends TestCase
         $this->assertEquals('valid-debug-to', $config->getDebugTo());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_an_array_of_ignored_codes()
     {
         $this->assertEquals([], $this->config()->getIgnoredErrorCodes()); // defaults to empty array
         $this->assertEquals([1, 2], $this->config(['ignored_error_codes' => [1, 2]])->getIgnoredErrorCodes());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_boolean_wether_the_error_code_is_ignored_or_not()
     {
         $config = $this->config(['ignored_error_codes' => [1, 2]]);
@@ -80,7 +81,7 @@ class TwilioConfigTest extends TestCase
         $this->assertTrue($config->isIgnoredErrorCode(3));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_boolean_wether_shorten_urls_is_enabled_or_not()
     {
         $this->assertFalse($this->config()->isShortenUrlsEnabled()); // defaults to false
@@ -88,7 +89,7 @@ class TwilioConfigTest extends TestCase
         $this->assertFalse($this->config(['shorten_urls' => false])->isShortenUrlsEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_boolean_wether_token_auth_is_used_or_not()
     {
         // No values set...
@@ -102,7 +103,7 @@ class TwilioConfigTest extends TestCase
         $this->assertTrue($this->config(['auth_token' => 'valid', 'account_sid' => 'valid'])->usingTokenAuth());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_boolean_wether_username_password_auth_is_used_or_not()
     {
         // No values set...

--- a/tests/Unit/TwilioMessageTestCase.php
+++ b/tests/Unit/TwilioMessageTestCase.php
@@ -4,19 +4,20 @@ namespace NotificationChannels\Twilio\Tests\Unit;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\Twilio\TwilioMessage;
+use PHPUnit\Framework\Attributes\Test;
 
 abstract class TwilioMessageTestCase extends MockeryTestCase
 {
     /** @var TwilioMessage */
     protected $message;
 
-    /** @test */
+    #[Test]
     abstract public function it_can_accept_a_message_when_constructing_a_message();
 
-    /** @test */
+    #[Test]
     abstract public function it_provides_a_create_method();
 
-    /** @test */
+    #[Test]
     public function it_can_set_the_content()
     {
         $this->message->content('myMessage');
@@ -24,7 +25,7 @@ abstract class TwilioMessageTestCase extends MockeryTestCase
         $this->assertEquals('myMessage', $this->message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_the_from()
     {
         $this->message->from('+1234567890');
@@ -32,7 +33,7 @@ abstract class TwilioMessageTestCase extends MockeryTestCase
         $this->assertEquals('+1234567890', $this->message->from);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_return_the_from_using_getter()
     {
         $this->message->from('+1234567890');

--- a/tests/Unit/TwilioMmsMessageTest.php
+++ b/tests/Unit/TwilioMmsMessageTest.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio\Tests\Unit;
 
 use NotificationChannels\Twilio\TwilioMmsMessage;
+use PHPUnit\Framework\Attributes\Test;
 
 class TwilioMmsMessageTest extends TwilioMessageTestCase
 {
@@ -13,7 +14,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->message = new TwilioMmsMessage;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_accept_a_message_when_constructing_a_message()
     {
         $message = new TwilioMmsMessage('myMessage');
@@ -21,7 +22,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('myMessage', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_a_create_method()
     {
         $message = TwilioMmsMessage::create('myMessage');
@@ -29,7 +30,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('myMessage', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_alphanumeric_sender()
     {
         $message = TwilioMmsMessage::create('myMessage');
@@ -38,7 +39,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('TestSender', $message->alphaNumSender);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_media_url()
     {
         $message = TwilioMmsMessage::create('myMessage');
@@ -47,7 +48,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('https://picsum.photos/300', $message->mediaUrl);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_return_the_alphanumeric_sender_if_set()
     {
         $message = TwilioMmsMessage::create('myMessage');
@@ -56,7 +57,7 @@ class TwilioMmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('TestSender', $message->getFrom());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_optional_parameters()
     {
         $message = TwilioMmsMessage::create('myMessage');

--- a/tests/Unit/TwilioSmsMessageTest.php
+++ b/tests/Unit/TwilioSmsMessageTest.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Twilio\Tests\Unit;
 
 use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit\Framework\Attributes\Test;
 
 class TwilioSmsMessageTest extends TwilioMessageTestCase
 {
@@ -13,7 +14,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->message = new TwilioSmsMessage;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_accept_a_message_when_constructing_a_message()
     {
         $message = new TwilioSmsMessage('myMessage');
@@ -21,7 +22,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('myMessage', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_a_create_method()
     {
         $message = TwilioSmsMessage::create('myMessage');
@@ -29,7 +30,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('myMessage', $message->content);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_alphanumeric_sender()
     {
         $message = TwilioSmsMessage::create('myMessage');
@@ -38,7 +39,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('TestSender', $message->alphaNumSender);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_return_the_alphanumeric_sender_if_set()
     {
         $message = TwilioSmsMessage::create('myMessage');
@@ -47,7 +48,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('TestSender', $message->getFrom());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_return_the_messaging_service_sid_if_set()
     {
         $message = TwilioSmsMessage::create('myMessage');
@@ -56,7 +57,7 @@ class TwilioSmsMessageTest extends TwilioMessageTestCase
         $this->assertEquals('TestSid', $message->getMessagingServiceSid());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_optional_parameters()
     {
         $message = TwilioSmsMessage::create('myMessage');

--- a/tests/Unit/TwilioTest.php
+++ b/tests/Unit/TwilioTest.php
@@ -12,6 +12,7 @@ use NotificationChannels\Twilio\TwilioConfig;
 use NotificationChannels\Twilio\TwilioMessage;
 use NotificationChannels\Twilio\TwilioMmsMessage;
 use NotificationChannels\Twilio\TwilioSmsMessage;
+use PHPUnit\Framework\Attributes\Test;
 use Twilio\Rest\Api\V2010\Account\CallInstance;
 use Twilio\Rest\Api\V2010\Account\CallList;
 use Twilio\Rest\Api\V2010\Account\MessageInstance;
@@ -48,7 +49,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio = new Twilio($this->twilioService, $this->config);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_to_twilio()
     {
         $message = new TwilioSmsMessage('Message text');
@@ -92,7 +93,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($message, '+1111111111');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_mms_message_to_twilio()
     {
         $message = new TwilioMmsMessage('Message text');
@@ -138,7 +139,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($message, '+1111111111');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_to_twilio_with_alphanumeric_sender()
     {
         $message = new TwilioSmsMessage('Message text');
@@ -172,7 +173,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($message, '+1111111111', true);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_sms_message_to_twilio_with_messaging_service()
     {
         $message = new TwilioSmsMessage('Message text');
@@ -205,7 +206,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($message, '+1111111111');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_a_call_to_twilio()
     {
         $message = new TwilioCallMessage('http://example.com');
@@ -237,7 +238,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($message, '+1111111111');
     }
 
-    /** @test */
+    #[Test]
     public function it_will_throw_an_exception_in_case_of_a_missing_from_number()
     {
         $this->expectException(CouldNotSendNotification::class);
@@ -264,7 +265,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage($smsMessage, null);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_throw_an_exception_in_case_of_an_unrecognized_message_object()
     {
         $this->expectException(CouldNotSendNotification::class);
@@ -273,7 +274,7 @@ class TwilioTest extends MockeryTestCase
         $this->twilio->sendMessage(new InvalidMessage, null);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_use_universal_to()
     {
         $debugTo = '+1222222222';


### PR DESCRIPTION
### Description

This PR adds laravel v12 support for this package. 

### Changes made

- composer.json
- test files

### Additional info

Several `Illuminate/*` components have been updated to version 12. These version have been updated in the `composer.json` file.

New phpunit version has depreciated the use of doc-comment metadata (such as annotations like `@test`). The necessary changes have been made in the test files for the new phpunit version.
 