### PR TITLE
Remove contentVariables from allowed SMS params

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -13,7 +13,8 @@ class Twilio
     public function __construct(
         protected TwilioService $twilioService,
         public TwilioConfig $config
-    ) {}
+    ) {
+    }
 
     /**
      * Send a TwilioMessage to a phone number.
@@ -89,7 +90,6 @@ class Twilio
             'scheduleType',
             'sendAt',
             'sendAsMms',
-            'contentVariables',
             'riskCheck',
         ]);
 


### PR DESCRIPTION
This should fix issue @ziming reported on https://github.com/laravel-notification-channels/twilio/pull/154 (Introduced by the merging of the PR and new release)