### PR TITLE
change check for optionalProperty to fix #162

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -175,7 +175,7 @@ class Twilio
     protected function fillOptionalParams(array &$params, TwilioMessage $message, array $optionalParams): self
     {
         foreach ($optionalParams as $optionalParam) {
-            if ($message->$optionalParam) {
+            if (property_exists($message, $optionalParam)) {
                 $params[$optionalParam] = $message->$optionalParam;
             }
         }


### PR DESCRIPTION
## Issue

$contentVariables does not exist exception

<img width="2294" height="511" alt="image" src="https://github.com/user-attachments/assets/0b3e6e19-6009-4f31-a2d6-84649f98a1b6" />

## fix details

By switching the check from raw $message->$optionalParam to a property_exists check we can remove the exception from occuring when the optionalParam ($contentVariables) from occurring.